### PR TITLE
Added pynuoadmin

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM library/python:3.12-slim
 
+ARG PYNUOADMIN_VERSION=2.4.0
+
 # Install runtime dependencies
 RUN set -ex; \
     apt-get update; \
@@ -20,7 +22,7 @@ RUN mkdir /opt/nuodb-operations \
     && chown 1000:0 /opt/nuodb-operations
 
 # Copy tools code as nuodb user
-USER 1000:1000
+USER 1000:0
 
 # Copy sidecar scripts
 COPY --chown=1000:0 config_watcher/requirements.txt /opt/config_watcher/requirements.txt
@@ -30,6 +32,16 @@ COPY --chown=1000:0 docker/entrypoint.sh /usr/local/bin/
 
 # Install tools requirements
 RUN pip3 install -r /opt/config_watcher/requirements.txt
+
+# Install pynuoadmin
+RUN pip3 install pynuoadmin==${PYNUOADMIN_VERSION}
+RUN echo "export NUOCMD_PYTHONPATH=$(pip show pynuoadmin | sed -ne 's|Location: \(.*\)|\1|p')" >> /home/nuodb/.profile
+
+ENV NUOCMD_CLIENT_KEY /etc/nuodb/keys/nuocmd.pem
+ENV NUOCMD_VERIFY_SERVER /etc/nuodb/keys/ca.cert
+
+ENV LANG en_US.UTF-8
+ENV HOME /home/nuodb
 
 ENTRYPOINT ["entrypoint.sh"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM library/python:3.12-slim
 
-ARG PYNUOADMIN_VERSION=2.4.0
+ARG PYNUOADMIN_VERSION=2.5.0
 
 # Install runtime dependencies
 RUN set -ex; \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -38,6 +38,9 @@ case "${uid}:${gid}" in
         ;;
 esac
 
+# Configure shell
+. /home/nuodb/.profile
+
 # Support well-known commands
 case "$1" in
     (config_watcher)

--- a/docker/user_setup
+++ b/docker/user_setup
@@ -32,11 +32,21 @@ cp /etc/passwd /etc/passwd.nuodb
   setup_dir /usr/local/bin  0775
   ) >/dev/null
 
-setup_file /home/nuodb/.bashrc <<"EOF"
+setup_file /home/nuodb/.profile <<"EOF"
 # Enable nss_wrapper if /tmp/passwd and /tmp/group exist
 if [ -f /tmp/passwd -a -f /tmp/group ]; then
     export LD_PRELOAD=libnss_wrapper.so
     export NSS_WRAPPER_PASSWD=/tmp/passwd
     export NSS_WRAPPER_GROUP=/tmp/group
 fi
+
+# Add nuocmd to the PATH
+export PATH=/home/nuodb/.local/bin:$PATH
+EOF
+
+setup_file /home/nuodb/.bashrc <<"EOF"
+[ -f /home/nuodb/.profile ] && . /home/nuodb/.profile
+
+# Enable tab completion for nuocmd
+. "/home/nuodb/.local/etc/nuocmd-complete"
 EOF


### PR DESCRIPTION
Added pynuoadmin in `nuodb/nuodb-sidecar` Docker image. This is required so
that the backup hooks server can pause/resume archiving using `nuocmd`. By
default all Python modules installed by `pip` go into `/home/nuodb/.local`
directory.  Setup the shell so that required environment variables for executing
`nuocmd` are exported.