### PR TITLE
Added metrics to backup hooks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
+          pip install -r nuodb-operations/test-requirements.txt
           pip install -r config_watcher/test-requirements.txt
           pip install -r config_watcher/requirements.txt
       - name: Test code formatting
@@ -50,11 +51,19 @@ jobs:
           path: test-results/reports/config_watcher.xml
           reporter: java-junit
           fail-on-error: true
+      - name: Test report
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: results-nuodb-operations-${{ matrix.python-version }}
+          path: test-results/reports/nuodb-operations.xml
+          reporter: java-junit
+          fail-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.python-version }}
           path: |
-            test-results/config_watcher
+            test-results
           retention-days: 7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,5 +65,6 @@ jobs:
         with:
           name: test-results-${{ matrix.python-version }}
           path: |
-            test-results
+            test-results/config_watcher
+            test-results/nuodb-operations
           retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -55,12 +55,17 @@ fmt:
 ##@ Testing
 
 .PHONY: test
-test: test-config-watcher ## Run tests
+test: test-nuodb-operations test-config-watcher ## Run tests
 
 test-config-watcher: test-setup
 	cd config_watcher \
 		&& python3 -m pytest \
 			--junitxml $(OUTPUT_DIR)/reports/config_watcher.xml
+
+test-nuodb-operations:
+	cd nuodb-operations \
+		&& python3 -m pytest \
+			--junitxml $(OUTPUT_DIR)/reports/nuodb-operations.xml
 
 test-setup: $(KWOKCTL) $(KUBECTL) ## Run tests setup
 	mkdir -p $(TMP_DIR)

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -47,9 +47,9 @@ VOLUME_AVAILABLE_BYTES = Gauge(
     label_names=["volume"],
 )
 
-ARCHIVE_FROZEN_SECONDS = Histogram(
-    "nuodb_archive_frozen_seconds",
-    description="Length of time for which the NuoDB archive was frozen.",
+BACKUP_DURATION_SECONDS = Histogram(
+    "snapshot_backup_duration_seconds",
+    description="Length of time for taking snapshot-based backup.",
     # fmt: off
     buckets=[
         0.5, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5,
@@ -340,6 +340,8 @@ def post_backup(backup_id, query):
         else:
             raise UserError(msg)
 
+    # Get backup file creation timestamp
+    ctime = get_backup_ctime()
     # Get nuodb processes
     processes = get_nuodb_process_info()
     if not processes:
@@ -350,16 +352,20 @@ def post_backup(backup_id, query):
     if JOURNAL_DIR is not None:
         try:
             freeze_archive(backup_id, processes, unfreeze=True)
-            ctime = get_backup_ctime()
-            if ctime:
-                ARCHIVE_FROZEN_SECONDS.observe(time.time() - ctime)
         except ArchivingNotPausedError:
             # Delete backup metadata files to allow new backups
             remove_backup_files()
+            # Record the snapshot duration even if the database archiving was
+            # already resumed due to internal engine timeout
+            if ctime:
+                BACKUP_DURATION_SECONDS.observe(time.time() - ctime)
             raise
 
     # Delete backup metadata files
     remove_backup_files()
+    # Record the total duration of the snapshot operation
+    if ctime:
+        BACKUP_DURATION_SECONDS.observe(time.time() - ctime)
 
 
 def remove_backup_files():

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -689,7 +689,10 @@ class HooksHandler(object):
                 matches, path_params = handler.matches(req.method, req.components)
                 if matches:
                     path = handler.path
-                    return handler.execute(path_params, req.query_params, req.payload)
+                    status, resp_data = handler.execute(
+                        path_params, req.query_params, req.payload
+                    )
+                    return status, resp_data
             # Dispatch to matching built-in handler
             path, resp_data = handle_method(req)
             if resp_data is None:

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -646,6 +646,14 @@ class HooksHandler(object):
     def __init__(self, handler_config=None):
         self.handlers = read_handler_config(handler_config)
         self.log_handlers()
+        # Register metric functions
+        VOLUME_AVAILABLE_BYTES.labels("archive-volume").set_function(
+            lambda: disk_usage(ARCHIVE_DIR)[2]
+        )
+        if JOURNAL_DIR:
+            VOLUME_AVAILABLE_BYTES.labels("journal-volume").set_function(
+                lambda: disk_usage(JOURNAL_DIR)[2]
+            )
 
     def log_handlers(self, indent=4):
         # Log all built-in handlers
@@ -692,9 +700,11 @@ class HooksHandler(object):
             status, data = create_error(e)
             return status, data
         finally:
-            HOOK_REQUEST_DURATION_SECONDS.labels(req.method, path, str(status)).observe(
-                time.time() - start_time
-            )
+            HOOK_REQUEST_DURATION_SECONDS.labels(
+                req.method,
+                "/" + normalize_path(path),
+                str(status),
+            ).observe(time.time() - start_time)
 
     def __call__(self, environ, start_response):
         status, json_response = self.handle(environ)
@@ -703,14 +713,6 @@ class HooksHandler(object):
 
 def start_server(port, handler_config):
     hooks_handler = HooksHandler(handler_config)
-    # Register metric functions
-    VOLUME_AVAILABLE_BYTES.labels("archive-volume").set_function(
-        lambda: disk_usage(ARCHIVE_DIR)[2]
-    )
-    if JOURNAL_DIR:
-        VOLUME_AVAILABLE_BYTES.labels("journal-volume").set_function(
-            lambda: disk_usage(JOURNAL_DIR)[2]
-        )
     with simple_server.make_server("", port, hooks_handler) as httpd:
         LOGGER.info("Starting backup hooks server on port %s", port)
         httpd.serve_forever()

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -12,7 +12,9 @@ import urllib
 import wsgiref
 from wsgiref import simple_server
 from threading import Timer
-from shutil import which
+from shutil import which, disk_usage
+
+from metrics import Gauge, Histogram, REGISTRY
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 LOGGER = logging.getLogger(__name__)
@@ -38,6 +40,29 @@ JOURNAL_BACKUP_ID_FILE = from_dir(JOURNAL_DIR, "backup.txt")
 BACKUP_PAYLOAD_FILE = from_dir(ARCHIVE_DIR, "backup_payload.txt")
 BACKUP_START_ID_FILE = from_dir(ARCHIVE_DIR, "backup_sid.txt")
 RESTORED_FILE = from_dir(ARCHIVE_DIR, "restored.txt")
+
+VOLUME_AVAILABLE_BYTES = Gauge(
+    "nuodb_volume_available_bytes",
+    description="Database volume available bytes.",
+    label_names=["volume"],
+)
+
+ARCHIVE_FROZEN_SECONDS = Histogram(
+    "nuodb_archive_frozen_seconds",
+    description="Length of time for which the NuoDB archive was frozen.",
+    # fmt: off
+    buckets=[
+        0.5, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5,
+        5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60, 70, 100, 120, 140, 160, 200, 250,
+    ],
+    # fmt: on
+)
+
+HOOK_REQUEST_DURATION_SECONDS = Histogram(
+    "hook_request_duration_seconds",
+    description="Total count of database archive freeze operations.",
+    label_names=["method", "endpoint", "http_status"],
+)
 
 
 def write_file(path, content):
@@ -325,6 +350,9 @@ def post_backup(backup_id, query):
     if JOURNAL_DIR is not None:
         try:
             freeze_archive(backup_id, processes, unfreeze=True)
+            ctime = get_backup_ctime()
+            if ctime:
+                ARCHIVE_FROZEN_SECONDS.observe(time.time() - ctime)
         except ArchivingNotPausedError:
             # Delete backup metadata files to allow new backups
             remove_backup_files()
@@ -349,6 +377,11 @@ def get_backup_id():
     if os.path.exists(ARCHIVE_BACKUP_ID_FILE):
         with open(ARCHIVE_BACKUP_ID_FILE, "r") as f:
             return f.read().strip()
+
+
+def get_backup_ctime():
+    if os.path.exists(ARCHIVE_BACKUP_ID_FILE):
+        return os.path.getctime(ARCHIVE_BACKUP_ID_FILE)
 
 
 def get_start_id():
@@ -410,6 +443,7 @@ def create_error(exc):
 REGISTERED_HANDLERS = [
     ("POST", "pre-backup", pre_backup),
     ("POST", "post-backup", post_backup),
+    ("GET", "metrics", lambda: REGISTRY.collect()),  # pylint: disable=W0108
 ]
 
 
@@ -584,8 +618,7 @@ def handle_method(req):
                     msg += ", including payload and query parameters"
                 raise UserError(msg)
             # Request is valid. Send it to handler.
-            handler(*args)
-            return
+            return path_prefix, handler(*args)
 
     # Handler was not found
     raise UserError("No handler found for path " + req.parsed.path)
@@ -638,18 +671,30 @@ class HooksHandler(object):
             LOGGER.info("Custom handlers:\n%s", "\n".join(custom_handlers))
 
     def handle(self, environ):
+        req = RequestInfo(environ)
+        start_time = time.time()
+        status = http.HTTPStatus.OK
+        path = f"/{'/'.join(req.components)}"
         try:
             # Dispatch to matching script handler
-            req = RequestInfo(environ)
             for handler in self.handlers:
                 matches, path_params = handler.matches(req.method, req.components)
                 if matches:
+                    path = handler.path
                     return handler.execute(path_params, req.query_params, req.payload)
             # Dispatch to matching built-in handler
-            handle_method(req)
-            return http.HTTPStatus.OK, dict(success=True)
+            path, resp_data = handle_method(req)
+            if resp_data is None:
+                # Return a trivial JSON response indicating success
+                resp_data = dict(success=True)
+            return status, resp_data
         except Exception as e:
-            return create_error(e)
+            status, data = create_error(e)
+            return status, data
+        finally:
+            HOOK_REQUEST_DURATION_SECONDS.labels(req.method, path, str(status)).observe(
+                time.time() - start_time
+            )
 
     def __call__(self, environ, start_response):
         status, json_response = self.handle(environ)
@@ -658,6 +703,14 @@ class HooksHandler(object):
 
 def start_server(port, handler_config):
     hooks_handler = HooksHandler(handler_config)
+    # Register metric functions
+    VOLUME_AVAILABLE_BYTES.labels("archive-volume").set_function(
+        lambda: disk_usage(ARCHIVE_DIR)[2]
+    )
+    if JOURNAL_DIR:
+        VOLUME_AVAILABLE_BYTES.labels("journal-volume").set_function(
+            lambda: disk_usage(JOURNAL_DIR)[2]
+        )
     with simple_server.make_server("", port, hooks_handler) as httpd:
         LOGGER.info("Starting backup hooks server on port %s", port)
         httpd.serve_forever()

--- a/nuodb-operations/metrics.py
+++ b/nuodb-operations/metrics.py
@@ -1,0 +1,301 @@
+import threading
+import re
+import json
+
+
+class MetricRegistry(object):
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._metrics = []
+
+    def register(self, metric):
+        with self._lock:
+            self._metrics += [metric]
+
+    def collect(self):
+        with self._lock:
+            lines = []
+            for m in self._metrics:
+                l = m.describe()
+                if l:
+                    lines += l
+            if lines:
+                return bytes("\n".join(lines) + "\n", "utf-8")
+
+
+REGISTRY = MetricRegistry()
+
+LABEL_NAME_PATTERN = re.compile("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
+
+INF = float("inf")
+
+
+class Metric(object):
+
+    _type = None
+
+    def __init__(
+        self,
+        name,
+        description=None,
+        label_names=None,
+        registry=REGISTRY,
+        suffix=None,
+        _label_values=None,
+    ):
+        self.name = name
+        self.description = description
+        self.suffix = suffix or ""
+
+        self._labelnames = Metric._validated_labelnames(label_names)
+        self._registry = registry
+        self._labelvalues = _label_values or ()
+        self._value = 0
+        self._childs = {}
+        self._lock = threading.Lock()
+        # Register the metric family with the registry
+        if not self._labelvalues:
+            self._registry.register(self)
+
+    def _header(self):
+        return [
+            f"# description {self.name} {self.description}",
+            f"# TYPE {self.name} {self._type}",
+        ]
+
+    @staticmethod
+    def _validated_labelnames(labelnames):
+        if labelnames is None:
+            return ()
+        for l in labelnames:
+            if not LABEL_NAME_PATTERN.match(l):
+                return ValueError(
+                    f"Invalid label name {l}. Must match {LABEL_NAME_PATTERN}"
+                )
+        return tuple(labelnames)
+
+    def _is_observable(self):
+        return not self._labelnames or (self._labelnames and self._labelvalues)
+
+    def _raise_if_not_observable(self):
+        if not self._is_observable():
+            raise ValueError(
+                "{} metric is missing label values actual={}, expected={}".format(
+                    str(self._type), len(self._labelvalues), len(self._labelnames)
+                )
+            )
+
+    @staticmethod
+    def _label_value(v):
+        if v == INF:
+            return "+Inf"
+        return json.dumps(v)
+
+    def _render_labels(self):
+        labels = []
+        for i in range(len(self._labelnames)):
+            labels += [
+                f"{self._labelnames[i]}={Metric._label_value(self._labelvalues[i])}"
+            ]
+        return labels
+
+    def _with_labels(self, labelnames, labelvalues):
+        if len(labelvalues) != len(labelnames):
+            raise ValueError(
+                f"Incorrect label count: actual={len(labelvalues)}, expected={len(labelnames)}"
+            )
+        if labelvalues in self._childs:
+            return self._childs[labelvalues]
+        metric = self.__class__(
+            self.name,
+            description=self.description,
+            label_names=labelnames,
+            registry=self._registry,
+            _label_values=labelvalues,
+        )
+        self._childs[labelvalues] = metric
+        return metric
+
+    def render_values(self):
+        if self._childs:
+            # return all metrics stored in the metrics family
+            lines = []
+            for _, m in self._childs.items():
+                v = m.render_values()
+                if v:
+                    lines += v
+            return lines
+        if not self._labelvalues:
+            return
+        labels = self._render_labels()
+        v = self._value
+        if callable(self._value):
+            v = self._value()
+        return [f"{self.name}{self.suffix}{{{", ".join(labels)}}} {v}"]
+
+    def set_value(self, value):
+        self._raise_if_not_observable()
+        with self._lock:
+            self._value = value
+
+    def inc(self, amount=1):
+        self.set_value(self._value + amount)
+
+    def set_function(self, f):
+        if not callable(f):
+            raise ValueError(f"Invalid function type {type(f)}")
+        self.set_value(f)
+
+    def labels(self, *labelvalues):
+        if not self._labelnames:
+            raise ValueError("No label names")
+        with self._lock:
+            return self._with_labels(self._labelnames, labelvalues)
+
+    def describe(self):
+        with self._lock:
+            values = self.render_values()
+            if values:
+                return self._header() + values
+
+
+class Gauge(Metric):
+    """Gauge metric, to report instantaneous values."""
+
+    _type = "gauge"
+
+    def __init__(
+        self,
+        name,
+        description=None,
+        label_names=None,
+        registry=REGISTRY,
+        _label_values=None,
+    ):
+        super().__init__(
+            name,
+            description=description,
+            label_names=label_names,
+            registry=registry,
+            _label_values=_label_values,
+        )
+
+    def observe(self, value):
+        self.set_value(value)
+
+
+class Counter(Metric):
+    """A Counter tracks counts of events or running totals."""
+
+    _type = "counter"
+
+    def __init__(
+        self,
+        name,
+        description=None,
+        label_names=None,
+        registry=REGISTRY,
+        _label_values=None,
+    ):
+        super().__init__(
+            name,
+            description=description,
+            label_names=label_names,
+            registry=registry,
+            _label_values=_label_values,
+        )
+
+    def inc(self, amount=1):
+        if amount < 0:
+            raise ValueError(
+                "Counters can only be incremented by non-negative amounts."
+            )
+        self.inc(amount)
+
+
+class Histogram(Metric):
+    """A Histogram tracks the size and number of events in buckets."""
+
+    DEFAULT_BUCKETS = (
+        0.005,
+        0.01,
+        0.025,
+        0.05,
+        0.075,
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        2.5,
+        5.0,
+        7.5,
+        10.0,
+        INF,
+    )
+
+    _type = "histogram"
+
+    def __init__(
+        self,
+        name,
+        description=None,
+        buckets=DEFAULT_BUCKETS,
+        label_names=None,
+        registry=REGISTRY,
+        _label_values=None,
+    ):
+        super().__init__(
+            name,
+            description=description,
+            label_names=label_names,
+            registry=registry,
+            _label_values=_label_values,
+        )
+        self.buckets = [float(b) for b in sorted(buckets)]
+        if self.buckets and self.buckets[-1] != INF:
+            self.buckets.append(INF)
+        self._bucket_counts = {}
+        self._sum = None
+        self._count = None
+
+    def _prepare_buckets(self):
+        for b in self.buckets:
+            self._bucket_counts[b] = self._with_labels(
+                ("le",) + self._labelnames, (b,) + self._labelvalues
+            )
+            self._bucket_counts[b].suffix = "_bucket"
+        self._sum = Metric(
+            self.name,
+            description=self.description,
+            label_names=self._labelnames,
+            registry=self._registry,
+            suffix="_sum",
+            _label_values=self._labelvalues,
+        )
+        self._childs[("__sum",)] = self._sum
+        self._count = Metric(
+            self.name,
+            description=self.description,
+            label_names=self._labelnames,
+            registry=self._registry,
+            suffix="_count",
+            _label_values=self._labelvalues,
+        )
+        self._childs[("__count",)] = self._count
+
+    def labels(self, *labelvalues):
+        metric = super().labels(*labelvalues)
+        metric.buckets = self.buckets
+        return metric
+
+    def observe(self, amount):
+        self._raise_if_not_observable()
+        with self._lock:
+            if self._count is None:
+                self._prepare_buckets()
+            self._sum.inc(amount)
+            self._count.inc()
+            for b in self.buckets:
+                if amount <= b:
+                    self._bucket_counts[b].inc()

--- a/nuodb-operations/metrics.py
+++ b/nuodb-operations/metrics.py
@@ -290,8 +290,7 @@ class Histogram(Metric):
         # create buckets
         for b in self.buckets:
             self._bucket_counts[b] = self._with_labels(
-                ("le",) + self._labelnames,
-                (b,) + self._labelvalues
+                ("le",) + self._labelnames, (b,) + self._labelvalues
             )
             self._bucket_counts[b].suffix = "_bucket"
             self._bucket_counts[b].inc(0)

--- a/nuodb-operations/metrics.py
+++ b/nuodb-operations/metrics.py
@@ -9,16 +9,17 @@ LOGGER = logging.getLogger(__name__)
 class MetricRegistry(object):
     def __init__(self):
         self._lock = threading.Lock()
-        self._metrics = []
+        self._metrics = {}
 
     def register(self, metric):
         with self._lock:
-            self._metrics += [metric]
+            if metric.name not in self._metrics:
+                self._metrics[metric.name] = metric
 
     def collect(self):
         with self._lock:
             lines = []
-            for m in self._metrics:
+            for m in self._metrics.values():
                 l = m.describe()
                 if l:
                     lines += l
@@ -95,6 +96,8 @@ class Metric(object):
             return "+Inf"
         if v is NaN:
             return "NaN"
+        if v is None:
+            return "NaN"
         return v
 
     @staticmethod
@@ -112,12 +115,11 @@ class Metric(object):
             try:
                 v = self._value()
             except Exception as e:
-                labels = ", ".join(self._render_labels())
                 LOGGER.warning(
-                    "Failed to get value for %s metric %s{%s}: %s",
+                    "Failed to get value for %s metric %s%s: %s",
                     self._type,
                     self.name,
-                    labels,
+                    self._render_labels(),
                     str(e),
                 )
                 v = NaN
@@ -129,7 +131,9 @@ class Metric(object):
             labels += [
                 f"{self._labelnames[i]}={Metric._label_value(self._labelvalues[i])}"
             ]
-        return labels
+        if not labels:
+            return ""
+        return f"{{{",".join(labels)}}}"
 
     def _with_labels(self, labelnames, labelvalues):
         if len(labelvalues) != len(labelnames):
@@ -157,12 +161,10 @@ class Metric(object):
                 if v:
                     lines += v
             return lines
-        if not self._labelvalues:
-            return
-        labels = self._render_labels()
-        return [
-            f"{self.name}{self.suffix}{{{", ".join(labels)}}} {self._render_value()}"
-        ]
+        if self._value is not None and (not self._labelnames or self._labelvalues):
+            return [
+                f"{self.name}{self.suffix}{self._render_labels()} {self._render_value()}"
+            ]
 
     def set_value(self, value):
         self._raise_if_not_observable()
@@ -170,7 +172,11 @@ class Metric(object):
             self._value = value
 
     def inc(self, amount=1):
-        self.set_value(self._value + amount)
+        self._raise_if_not_observable()
+        with self._lock:
+            if self._value is None:
+                self._value = 0
+            self._value += amount
 
     def set_function(self, f):
         if not callable(f):
@@ -241,29 +247,17 @@ class Counter(Metric):
             raise ValueError(
                 "Counters can only be incremented by non-negative amounts."
             )
-        self.inc(amount)
+        super().inc(amount)
 
 
 class Histogram(Metric):
     """A Histogram tracks the size and number of events in buckets."""
 
+    # fmt: off
     DEFAULT_BUCKETS = (
-        0.005,
-        0.01,
-        0.025,
-        0.05,
-        0.075,
-        0.1,
-        0.25,
-        0.5,
-        0.75,
-        1.0,
-        2.5,
-        5.0,
-        7.5,
-        10.0,
-        INF,
+        0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, INF,
     )
+    # fmt: on
 
     _type = "histogram"
 
@@ -289,13 +283,19 @@ class Histogram(Metric):
         self._bucket_counts = {}
         self._sum = None
         self._count = None
+        # suppress the parent series
+        self._value = None
 
     def _prepare_buckets(self):
+        # create buckets
         for b in self.buckets:
             self._bucket_counts[b] = self._with_labels(
-                ("le",) + self._labelnames, (b,) + self._labelvalues
+                ("le",) + self._labelnames,
+                (b,) + self._labelvalues
             )
             self._bucket_counts[b].suffix = "_bucket"
+            self._bucket_counts[b].inc(0)
+        # create count and sum series
         self._sum = Metric(
             self.name,
             description=self.description,

--- a/nuodb-operations/metrics.py
+++ b/nuodb-operations/metrics.py
@@ -1,6 +1,9 @@
 import threading
 import re
 import json
+import logging
+
+LOGGER = logging.getLogger(__name__)
 
 
 class MetricRegistry(object):
@@ -28,6 +31,7 @@ REGISTRY = MetricRegistry()
 LABEL_NAME_PATTERN = re.compile("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
 
 INF = float("inf")
+NaN = float("NaN")
 
 
 class Metric(object):
@@ -59,7 +63,7 @@ class Metric(object):
 
     def _header(self):
         return [
-            f"# description {self.name} {self.description}",
+            f"# HELP {self.name} {self.description}",
             f"# TYPE {self.name} {self._type}",
         ]
 
@@ -86,10 +90,38 @@ class Metric(object):
             )
 
     @staticmethod
-    def _label_value(v):
+    def _normalize_value(v):
         if v == INF:
             return "+Inf"
+        if v is NaN:
+            return "NaN"
+        return v
+
+    @staticmethod
+    def _label_value(v):
+        v = Metric._normalize_value(v)
+        if isinstance(v, float):
+            # labels are strings
+            v = f"{v}"
         return json.dumps(v)
+
+    def _render_value(self):
+        v = self._value
+        if callable(self._value):
+            # Call value function
+            try:
+                v = self._value()
+            except Exception as e:
+                labels = ", ".join(self._render_labels())
+                LOGGER.warning(
+                    "Failed to get value for %s metric %s{%s}: %s",
+                    self._type,
+                    self.name,
+                    labels,
+                    str(e),
+                )
+                v = NaN
+        return Metric._normalize_value(v)
 
     def _render_labels(self):
         labels = []
@@ -128,10 +160,9 @@ class Metric(object):
         if not self._labelvalues:
             return
         labels = self._render_labels()
-        v = self._value
-        if callable(self._value):
-            v = self._value()
-        return [f"{self.name}{self.suffix}{{{", ".join(labels)}}} {v}"]
+        return [
+            f"{self.name}{self.suffix}{{{", ".join(labels)}}} {self._render_value()}"
+        ]
 
     def set_value(self, value):
         self._raise_if_not_observable()

--- a/nuodb-operations/test-requirements.txt
+++ b/nuodb-operations/test-requirements.txt
@@ -1,0 +1,3 @@
+pylint==3.3.3
+pytest==8.3.4
+black==24.10.0

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python
+
+import logging
+import os
+import shutil
+import unittest
+from unittest import mock
+import socket
+import time
+import importlib
+import json
+import uuid
+import http
+from http.client import HTTPConnection
+from threading import Thread
+from wsgiref.simple_server import make_server
+
+import backup_hooks
+import metrics
+from backup_hooks import HooksHandler, LOGGER
+
+LOGGER.setLevel(logging.DEBUG)
+
+
+def retry(check_fn, timeout, initial_delay=0.25, max_delay=5):
+    delay = initial_delay
+    start_time = time.time()
+    while True:
+        try:
+            return check_fn()
+        except Exception:
+            remaining = timeout - (time.time() - start_time)
+            if remaining > 0:
+                time.sleep(max(initial_delay, min(remaining, delay)))
+                delay = min(max_delay, 2 * delay)
+            else:
+                raise
+
+
+class ConfigOverrides(object):
+    def __init__(self, **overrides):
+        self.overrides = overrides
+
+    def __call__(self, testMethod):
+        testMethod.overrides = self.overrides
+        return testMethod
+
+
+class BackupHooksTest(unittest.TestCase):
+    hooks_dir = os.path.dirname(os.path.abspath(__file__))
+    test_results_dir = os.path.join(
+        os.path.dirname(hooks_dir), "test-results", "nuodb-operations"
+    )
+
+    def path(self, *args):
+        return os.path.join(self.test_dir, *args)
+
+    @classmethod
+    def setUpClass(cls):
+        # create test results directories
+        os.makedirs(cls.test_results_dir, exist_ok=True)
+        cls.tmp_dir = os.path.join(cls.test_results_dir, "tmp", cls.__name__)
+        # clean and re-create tmp diretory
+        shutil.rmtree(cls.tmp_dir, ignore_errors=True)
+        os.makedirs(cls.tmp_dir)
+        # placeholder for server configuration
+        cls.server_config = {}
+
+    @staticmethod
+    def get_local_port():
+        sock = socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()
+        sock.close()
+        return port[1]
+
+    def get_server_config(self):
+        config = getattr(self, "server_config", {})
+        testMethod = getattr(self, self._testMethodName)
+        overrides = getattr(testMethod, "overrides", {})
+        config.update(overrides)
+        return config
+
+    def mock_functions(self):
+        server_config = self.get_server_config()
+        nuodb_processes = server_config.get(
+            "nuodb_processes", [{"pid": 1234, "sid": 0}]
+        )
+        self.nuodb_processes_patch = mock.patch(
+            "backup_hooks.get_nuodb_process_info", return_value=nuodb_processes
+        )
+        self.nuodb_processes_mock = self.nuodb_processes_patch.start()
+
+    def setUp(self):
+        # Create test tmp directory
+        self.test_dir = os.path.join(self.tmp_dir, self._testMethodName)
+        os.makedirs(self.test_dir)
+        # Configure the server
+        self.original_env = os.environ
+        self.archive_dir = os.path.join(self.test_dir, "archive")
+        os.makedirs(self.archive_dir)
+        os.environ["NUODB_ARCHIVE_DIR"] = self.archive_dir
+        # Apply overrides
+        server_config = self.get_server_config()
+        if server_config.get("external_journal", False):
+            self.journal_dir = os.path.join(self.test_dir, "journal")
+            os.makedirs(self.journal_dir)
+            os.environ["NUODB_JOURNAL_DIR"] = self.journal_dir
+        # Reload ensures that env changes are picked up and metrics are reset
+        importlib.reload(backup_hooks)
+        importlib.reload(metrics)
+        # Mock functions
+        self.mock_functions()
+        # Start backup hooks server
+        self.host = "127.0.0.1"
+        self.port = self.get_local_port()
+        self.start_server()
+        self._wait_until_ready()
+
+    def tearDown(self):
+        self.stop_server()
+        self.nuodb_processes_patch.stop()
+        # Restore environment variables
+        os.environ.clear()
+        os.environ.update(self.original_env)
+
+    def _wait_until_ready(self, timeout=5):
+        def _connect():
+            conn = HTTPConnection(self.host, self.port)
+            conn.connect()
+            conn.close()
+
+        retry(lambda: _connect(), timeout)
+
+    def _wait_until_stopped(self, timeout=5):
+        def _connect():
+            conn = HTTPConnection(self.host, self.port)
+            try:
+                conn.connect()
+                raise RuntimeError("Server is running")
+            except Exception:
+                return
+            finally:
+                conn.close()
+
+        retry(lambda: _connect(), timeout)
+
+    def start_server(self, handler_config=None):
+        LOGGER.info("Starting server on %s:%d", self.host, self.port)
+        self.httpd = make_server(self.host, self.port, HooksHandler(handler_config))
+        self.server_thread = Thread(target=self.httpd.serve_forever, daemon=True)
+        self.server_thread.start()
+        self._wait_until_ready()
+
+    def stop_server(self):
+        if self.httpd:
+            self.httpd.shutdown()
+            self.httpd.server_close()
+            self.server_thread.join()
+            self._wait_until_stopped()
+            LOGGER.info("Server stopped")
+
+    def request(self, path="/", method="GET", body=None, headers=None):
+        headers = headers or {}
+        conn = HTTPConnection(self.host, self.port)
+        try:
+            conn.request(method, path, body=body, headers=headers)
+            resp = conn.getresponse()
+            data = resp.read()
+            return resp, data
+        finally:
+            conn.close()
+
+    def pre_backup(self, backup_id, opaque=None):
+        resp, data = self.request(
+            method="POST",
+            path=f"/pre-backup/{backup_id}",
+            body=json.dumps(dict(opaque=opaque)),
+            headers={"Content-Type": "application/json"},
+        )
+        return resp, json.loads(data)
+
+    def post_backup(self, backup_id, force=False):
+        resp, data = self.request(
+            method="POST",
+            path=f"/post-backup/{backup_id}?force={str(force).lower()}",
+        )
+        return resp, json.loads(data)
+
+    def assertFileContent(self, name, content):
+        file = self.path(name)
+        self.assertTrue(os.path.isfile(file), f"File {file} does not exist")
+        with open(file, "r") as f:
+            actual = f.read()
+            self.assertEqual(content, actual, f"File {file} content differ")
+
+    def assertFileNotExist(self, name):
+        file = self.path(name)
+        self.assertFalse(os.path.exists(file), f"File {file} still exists")
+
+    @mock.patch("backup_hooks.freeze_archive")
+    def testPrePostHooks(self, freeze_archive_mock=None):
+        external_journal = self.get_server_config().get("external_journal", False)
+        backup_id = str(uuid.uuid4())
+
+        # Invoke pre-backup hook
+        user_data = "user data to store"
+        resp, data = self.pre_backup(backup_id, opaque=user_data)
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        self.assertTrue(data["success"], "pre-backup hook reported failure")
+
+        # verify that backup.txt and backup_payload.txt files are created
+        self.assertFileContent(os.path.join(self.archive_dir, "backup.txt"), backup_id)
+        self.assertFileContent(
+            os.path.join(self.archive_dir, "backup_payload.txt"), user_data
+        )
+        # check if the archive is frozen; the archive should be frozen only if
+        # external journal is enabled
+        if not external_journal:
+            freeze_archive_mock.assert_not_called()
+        else:
+            freeze_archive_mock.assert_called_once_with(
+                backup_id, self.nuodb_processes_mock.return_value, timeout=None
+            )
+
+        # negative test: invoke post-backup with bogus backup_id
+        resp, data = self.post_backup("bogus")
+        self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status, str(data))
+        self.assertFalse(data["success"], "post-backup hook reported success")
+        self.assertIn(
+            f"Unexpected backup ID: current={backup_id}, supplied=bogus",
+            data.get("message"),
+        )
+
+        # Invoke post-backup hook
+        resp, data = self.post_backup(backup_id)
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        self.assertTrue(data["success"], "post-backup hook reported failure")
+
+        # verify that backup.txt and backup_payload.txt files are removed
+        self.assertFileNotExist(os.path.join(self.archive_dir, "backup.txt"))
+        self.assertFileNotExist(os.path.join(self.archive_dir, "backup_payload.txt"))
+
+        # check if the archive is unfrozen; the archive should be unfrozen only
+        # if external journal is enabled
+        if not external_journal:
+            freeze_archive_mock.assert_not_called()
+        else:
+            freeze_archive_mock.assert_called_with(
+                backup_id, self.nuodb_processes_mock.return_value, unfreeze=True
+            )
+
+        # negative test: invoking post-backup again should fail
+        resp, data = self.post_backup(backup_id)
+        self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status, str(data))
+        self.assertFalse(data["success"], "post-backup hook reported success")
+        self.assertIn(
+            f"Unexpected backup ID: current=None, supplied={backup_id}",
+            data.get("message"),
+        )
+
+    def testVolumeMetrics(self):
+        external_journal = self.get_server_config().get("external_journal", False)
+
+        # request metrics endpoint
+        resp, data = self.request(method="GET", path="/metrics")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        out = data.decode("utf-8")
+
+        # verify that volume metrics are reported
+        self.assertRegex(
+            out, 'nuodb_volume_available_bytes{volume="archive-volume"} [0-9]+'
+        )
+        if self.get_server_config().get("external_journal", False):
+            self.assertRegex(
+                out, 'nuodb_volume_available_bytes{volume="journal-volume"} [0-9]+'
+            )
+        else:
+            self.assertNotIn(
+                'nuodb_volume_available_bytes{volume="journal-volume"}', out
+            )
+
+        # request metrics endpoint again
+        resp, data = self.request(method="GET", path="/metrics")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        out = data.decode("utf-8")
+
+        # verify that hook request latency Histogram is emitted
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="1.0", method="GET", endpoint="/metrics", http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf", method="GET", endpoint="/metrics", http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf", method="GET", endpoint="/metrics", http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_count{method="GET", endpoint="/metrics", http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_sum{method="GET", endpoint="/metrics", http_status="200"}',
+            out,
+        )
+
+        if external_journal:
+            # call backup hooks
+            backup_id = str(uuid.uuid4())
+            self.pre_backup(backup_id)
+            time.sleep(2.5)
+            self.post_backup(backup_id)
+
+            # request metrics endpoint again
+            resp, data = self.request(method="GET", path="/metrics")
+            self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+            out = data.decode("utf-8")
+
+            # verify that nuodb_archive_frozen_seconds Histogram is emitted
+            self.assertIn('nuodb_archive_frozen_seconds_bucket{le="1.0"} 0', out)
+            self.assertIn('nuodb_archive_frozen_seconds_bucket{le="2.0"} 0', out)
+            self.assertIn('nuodb_archive_frozen_seconds_bucket{le="3.0"} 1', out)
+            self.assertIn('nuodb_archive_frozen_seconds_bucket{le="4.0"} 1', out)
+            self.assertIn('nuodb_archive_frozen_seconds_bucket{le="+Inf"} 1', out)
+            # TODO(siv3): figure out why fails
+            # self.assertIn("nuodb_archive_frozen_seconds_count 1", out)
+            # self.assertIn('nuodb_archive_frozen_seconds_sum', out)
+
+
+class BackupHooksExternalJournalTest(BackupHooksTest):
+
+    def mock_functions(self):
+        super().mock_functions()
+        self.freeze_archive_patch = mock.patch("backup_hooks.freeze_archive")
+        self.freeze_archive_mock = self.freeze_archive_patch.start()
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.server_config = dict(external_journal=True)
+
+    def tearDown(self):
+        super().tearDown()
+        self.freeze_archive_patch.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -15,8 +15,8 @@ from http.client import HTTPConnection
 from threading import Thread
 from wsgiref.simple_server import make_server
 
-import backup_hooks
 import metrics
+import backup_hooks
 from backup_hooks import HooksHandler, LOGGER
 
 LOGGER.setLevel(logging.DEBUG)
@@ -99,8 +99,8 @@ class BackupHooksTest(unittest.TestCase):
             with open(handler_config, "w") as f:
                 f.write(json.dumps(dict(handlers=custom_handlers)))
         # Reload ensures that env changes are picked up and metrics are reset
-        importlib.reload(backup_hooks)
         importlib.reload(metrics)
+        importlib.reload(backup_hooks)
         # Mock functions
         self.mock_functions()
         return handler_config
@@ -279,9 +279,7 @@ class BackupHooksTest(unittest.TestCase):
             }
         ]
     )
-    def testVolumeMetrics(self):
-        external_journal = self.get_server_config().get("external_journal", False)
-
+    def testMetrics(self):
         # request metrics endpoint
         resp, data = self.request(method="GET", path="/metrics")
         self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
@@ -307,47 +305,46 @@ class BackupHooksTest(unittest.TestCase):
 
         # verify that hook request latency Histogram is emitted
         self.assertIn(
-            'hook_request_duration_seconds_bucket{le="1.0", method="GET", endpoint="/metrics", http_status="200"} 1',
+            'hook_request_duration_seconds_bucket{le="1.0",method="GET",endpoint="/metrics",http_status="200"} 1',
             out,
         )
         self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf", method="GET", endpoint="/metrics", http_status="200"} 1',
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/metrics",http_status="200"} 1',
             out,
         )
         self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf", method="GET", endpoint="/metrics", http_status="200"} 1',
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/metrics",http_status="200"} 1',
             out,
         )
         self.assertIn(
-            'hook_request_duration_seconds_count{method="GET", endpoint="/metrics", http_status="200"} 1',
+            'hook_request_duration_seconds_count{method="GET",endpoint="/metrics",http_status="200"} 1',
             out,
         )
         self.assertIn(
-            'hook_request_duration_seconds_sum{method="GET", endpoint="/metrics", http_status="200"}',
+            'hook_request_duration_seconds_sum{method="GET",endpoint="/metrics",http_status="200"}',
             out,
         )
 
-        if external_journal:
-            # call backup hooks
-            backup_id = str(uuid.uuid4())
-            self.pre_backup(backup_id)
-            time.sleep(2.5)
-            self.post_backup(backup_id)
+        # call backup hooks
+        backup_id = str(uuid.uuid4())
+        resp, data = self.pre_backup(backup_id)
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        time.sleep(0.6)
+        resp, data = self.post_backup(backup_id)
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
 
-            # request metrics endpoint again
-            resp, data = self.request(method="GET", path="/metrics")
-            self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
-            out = data.decode("utf-8")
+        # request metrics endpoint again
+        resp, data = self.request(method="GET", path="/metrics")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        out = data.decode("utf-8")
 
-            # verify that nuodb_archive_frozen_seconds Histogram is emitted
-            self.assertIn('nuodb_archive_frozen_seconds_bucket{le="1.0"} 0', out)
-            self.assertIn('nuodb_archive_frozen_seconds_bucket{le="2.0"} 0', out)
-            self.assertIn('nuodb_archive_frozen_seconds_bucket{le="3.0"} 1', out)
-            self.assertIn('nuodb_archive_frozen_seconds_bucket{le="4.0"} 1', out)
-            self.assertIn('nuodb_archive_frozen_seconds_bucket{le="+Inf"} 1', out)
-            # TODO(siv3): figure out why fails
-            # self.assertIn("nuodb_archive_frozen_seconds_count 1", out)
-            # self.assertIn('nuodb_archive_frozen_seconds_sum', out)
+        # verify that nuodb_archive_frozen_seconds Histogram is emitted
+        self.assertIn('snapshot_backup_duration_seconds_bucket{le="0.5"} 0', out)
+        self.assertIn('snapshot_backup_duration_seconds_bucket{le="1.0"} 1', out)
+        self.assertIn('snapshot_backup_duration_seconds_bucket{le="+Inf"} 1', out)
+        self.assertIn("snapshot_backup_duration_seconds_count 1", out)
+        self.assertIn("snapshot_backup_duration_seconds_sum", out)
+        self.assertNotIn("snapshot_backup_duration_seconds 0", out)
 
         # request custom handler
         resp, data = self.request(method="GET", path="/exit")
@@ -364,39 +361,39 @@ class BackupHooksTest(unittest.TestCase):
 
         # verify that hook request latency Histogram is emitted
         self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf", method="GET", endpoint="/exit", http_status="200"} 1',
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="200"} 1',
             out,
         )
         self.assertIn(
-            'hook_request_duration_seconds_count{method="GET", endpoint="/exit", http_status="200"} 1',
+            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="200"} 1',
             out,
         )
         self.assertIn(
-            'hook_request_duration_seconds_sum{method="GET", endpoint="/exit", http_status="200"}',
+            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="200"}',
             out,
         )
         self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf", method="GET", endpoint="/exit", http_status="500"} 1',
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="500"} 1',
             out,
         )
         self.assertIn(
-            'hook_request_duration_seconds_count{method="GET", endpoint="/exit", http_status="500"} 1',
+            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="500"} 1',
             out,
         )
         self.assertIn(
-            'hook_request_duration_seconds_sum{method="GET", endpoint="/exit", http_status="500"}',
+            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="500"}',
             out,
         )
         self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf", method="GET", endpoint="/exit", http_status="400"} 1',
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="400"} 1',
             out,
         )
         self.assertIn(
-            'hook_request_duration_seconds_count{method="GET", endpoint="/exit", http_status="400"} 1',
+            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="400"} 1',
             out,
         )
         self.assertIn(
-            'hook_request_duration_seconds_sum{method="GET", endpoint="/exit", http_status="400"}',
+            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="400"}',
             out,
         )
 

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -81,6 +81,30 @@ class BackupHooksTest(unittest.TestCase):
         config.update(overrides)
         return config
 
+    def configure_server(self):
+        server_config = self.get_server_config()
+        # Configure environment variables
+        self.archive_dir = os.path.join(self.test_dir, "archive")
+        os.makedirs(self.archive_dir)
+        os.environ["NUODB_ARCHIVE_DIR"] = self.archive_dir
+        if server_config.get("external_journal", False):
+            self.journal_dir = os.path.join(self.test_dir, "journal")
+            os.makedirs(self.journal_dir)
+            os.environ["NUODB_JOURNAL_DIR"] = self.journal_dir
+        # Configure custom handlers
+        handler_config = None
+        custom_handlers = server_config.get("custom_handlers")
+        if custom_handlers:
+            handler_config = os.path.join(self.test_dir, "handlers.json")
+            with open(handler_config, "w") as f:
+                f.write(json.dumps(dict(handlers=custom_handlers)))
+        # Reload ensures that env changes are picked up and metrics are reset
+        importlib.reload(backup_hooks)
+        importlib.reload(metrics)
+        # Mock functions
+        self.mock_functions()
+        return handler_config
+
     def mock_functions(self):
         server_config = self.get_server_config()
         nuodb_processes = server_config.get(
@@ -97,23 +121,6 @@ class BackupHooksTest(unittest.TestCase):
         os.makedirs(self.test_dir)
         # Configure the server
         self.original_env = os.environ
-        self.archive_dir = os.path.join(self.test_dir, "archive")
-        os.makedirs(self.archive_dir)
-        os.environ["NUODB_ARCHIVE_DIR"] = self.archive_dir
-        # Apply overrides
-        server_config = self.get_server_config()
-        if server_config.get("external_journal", False):
-            self.journal_dir = os.path.join(self.test_dir, "journal")
-            os.makedirs(self.journal_dir)
-            os.environ["NUODB_JOURNAL_DIR"] = self.journal_dir
-        # Reload ensures that env changes are picked up and metrics are reset
-        importlib.reload(backup_hooks)
-        importlib.reload(metrics)
-        # Mock functions
-        self.mock_functions()
-        # Start backup hooks server
-        self.host = "127.0.0.1"
-        self.port = self.get_local_port()
         self.start_server()
         self._wait_until_ready()
 
@@ -146,7 +153,10 @@ class BackupHooksTest(unittest.TestCase):
         retry(lambda: _connect(), timeout)
 
     def start_server(self, handler_config=None):
-        LOGGER.info("Starting server on %s:%d", self.host, self.port)
+        handler_config = self.configure_server()
+        self.host = "127.0.0.1"
+        self.port = self.get_local_port()
+        LOGGER.info("Starting hooks server on %s:%d", self.host, self.port)
         self.httpd = make_server(self.host, self.port, HooksHandler(handler_config))
         self.server_thread = Thread(target=self.httpd.serve_forever, daemon=True)
         self.server_thread.start()
@@ -259,6 +269,16 @@ class BackupHooksTest(unittest.TestCase):
             data.get("message"),
         )
 
+    @ConfigOverrides(
+        custom_handlers=[
+            {
+                "method": "GET",
+                "path": "/exit",
+                "script": "exit ${code:=0}",
+                "statusMappings": {"1": 500, "2": 400},
+            }
+        ]
+    )
     def testVolumeMetrics(self):
         external_journal = self.get_server_config().get("external_journal", False)
 
@@ -328,6 +348,57 @@ class BackupHooksTest(unittest.TestCase):
             # TODO(siv3): figure out why fails
             # self.assertIn("nuodb_archive_frozen_seconds_count 1", out)
             # self.assertIn('nuodb_archive_frozen_seconds_sum', out)
+
+        # request custom handler
+        resp, data = self.request(method="GET", path="/exit")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        resp, data = self.request(method="GET", path="/exit?code=1")
+        self.assertEqual(http.HTTPStatus.INTERNAL_SERVER_ERROR, resp.status, str(data))
+        resp, data = self.request(method="GET", path="/exit?code=2")
+        self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status, str(data))
+
+        # request metrics endpoint again
+        resp, data = self.request(method="GET", path="/metrics")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        out = data.decode("utf-8")
+
+        # verify that hook request latency Histogram is emitted
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf", method="GET", endpoint="/exit", http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_count{method="GET", endpoint="/exit", http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_sum{method="GET", endpoint="/exit", http_status="200"}',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf", method="GET", endpoint="/exit", http_status="500"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_count{method="GET", endpoint="/exit", http_status="500"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_sum{method="GET", endpoint="/exit", http_status="500"}',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf", method="GET", endpoint="/exit", http_status="400"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_count{method="GET", endpoint="/exit", http_status="400"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_sum{method="GET", endpoint="/exit", http_status="400"}',
+            out,
+        )
 
 
 class BackupHooksExternalJournalTest(BackupHooksTest):


### PR DESCRIPTION
**Changes**

This change adds metrics support in the backup hooks sidecar. Several new
metrics have been added, including volume available bytes, which are needed for
the automatic volume expansion feature in NuoDB CP. The Prometheus client
library is not used to avoid CVEs, but instead, a minimal implementation of
OpenMetrics is added.

**Testing**

- sample testing framework has been added along with several tests

**Example**

```
# HELP nuodb_volume_available_bytes Database volume available bytes.
# TYPE nuodb_volume_available_bytes gauge
nuodb_volume_available_bytes{volume="archive-volume"} 411970039808
nuodb_volume_available_bytes{volume="journal-volume"} 411970039808
# HELP nuodb_archive_frozen_seconds Length of time for which the NuoDB archive was frozen.
# TYPE nuodb_archive_frozen_seconds histogram
nuodb_archive_frozen_seconds_bucket{le="0.5"} 0
nuodb_archive_frozen_seconds_bucket{le="1.0"} 0
nuodb_archive_frozen_seconds_bucket{le="1.25"} 0
nuodb_archive_frozen_seconds_bucket{le="1.5"} 0
nuodb_archive_frozen_seconds_bucket{le="1.75"} 0
nuodb_archive_frozen_seconds_bucket{le="2.0"} 0
nuodb_archive_frozen_seconds_bucket{le="2.5"} 0
nuodb_archive_frozen_seconds_bucket{le="3.0"} 1
nuodb_archive_frozen_seconds_bucket{le="3.5"} 1
nuodb_archive_frozen_seconds_bucket{le="4.0"} 1
nuodb_archive_frozen_seconds_bucket{le="4.5"} 1
nuodb_archive_frozen_seconds_bucket{le="5.0"} 1
nuodb_archive_frozen_seconds_bucket{le="6.0"} 1
nuodb_archive_frozen_seconds_bucket{le="7.0"} 1
nuodb_archive_frozen_seconds_bucket{le="8.0"} 1
nuodb_archive_frozen_seconds_bucket{le="9.0"} 1
nuodb_archive_frozen_seconds_bucket{le="10.0"} 1
nuodb_archive_frozen_seconds_bucket{le="15.0"} 1
nuodb_archive_frozen_seconds_bucket{le="20.0"} 1
nuodb_archive_frozen_seconds_bucket{le="25.0"} 1
nuodb_archive_frozen_seconds_bucket{le="30.0"} 1
nuodb_archive_frozen_seconds_bucket{le="40.0"} 1
nuodb_archive_frozen_seconds_bucket{le="50.0"} 1
nuodb_archive_frozen_seconds_bucket{le="60.0"} 1
nuodb_archive_frozen_seconds_bucket{le="70.0"} 1
nuodb_archive_frozen_seconds_bucket{le="100.0"} 1
nuodb_archive_frozen_seconds_bucket{le="120.0"} 1
nuodb_archive_frozen_seconds_bucket{le="140.0"} 1
nuodb_archive_frozen_seconds_bucket{le="160.0"} 1
nuodb_archive_frozen_seconds_bucket{le="200.0"} 1
nuodb_archive_frozen_seconds_bucket{le="250.0"} 1
nuodb_archive_frozen_seconds_bucket{le="+Inf"} 1
nuodb_archive_frozen_seconds_count 1
nuodb_archive_frozen_seconds_sum 2.63400000
hook_request_duration_seconds_bucket{le="0.005", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.01", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.025", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.05", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.075", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.1", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.25", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.5", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.75", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="1.0", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="2.5", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="5.0", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="7.5", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="10.0", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="+Inf", method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_sum{method="POST", endpoint="/pre-backup", http_status="200"} 0.0022809505462646484
hook_request_duration_seconds_count{method="POST", endpoint="/pre-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.005", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.01", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.025", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.05", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.075", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.1", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.25", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.5", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="0.75", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="1.0", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="2.5", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="5.0", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="7.5", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="10.0", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_bucket{le="+Inf", method="POST", endpoint="/post-backup", http_status="200"} 1
hook_request_duration_seconds_sum{method="POST", endpoint="/post-backup", http_status="200"} 0.001466989517211914
hook_request_duration_seconds_count{method="POST", endpoint="/post-backup", http_status="200"} 1
# HELP hook_request_duration_seconds Total count of database archive freeze operations.
# TYPE hook_request_duration_seconds histogram
hook_request_duration_seconds_bucket{le="0.005", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="0.01", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="0.025", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="0.05", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="0.075", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="0.1", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="0.25", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="0.5", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="0.75", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="1.0", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="2.5", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="5.0", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="7.5", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="10.0", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="+Inf", method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_sum{method="GET", endpoint="/metrics", http_status="200"} 0.0032410621643066406
hook_request_duration_seconds_count{method="GET", endpoint="/metrics", http_status="200"} 6
hook_request_duration_seconds_bucket{le="0.005", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="0.01", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="0.025", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="0.05", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="0.075", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="0.1", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="0.25", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="0.5", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="0.75", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="1.0", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="2.5", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="5.0", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="7.5", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="10.0", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_bucket{le="+Inf", method="GET", endpoint="/favicon.ico", http_status="400"} 6
hook_request_duration_seconds_sum{method="GET", endpoint="/favicon.ico", http_status="400"} 0.00021338462829589844
hook_request_duration_seconds_count{method="GET", endpoint="/favicon.ico", http_status="400"} 6
```