### PR TITLE
[HELM-471] Sidecar container for pods without an archive

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,9 +24,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-      - name: Install dependencies
-        run: |
-          make python-libs
       - name: Test code formatting
         run: |
           make fmt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,9 +26,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          pip install -r nuodb-operations/test-requirements.txt
-          pip install -r config_watcher/test-requirements.txt
-          pip install -r config_watcher/requirements.txt
+          make python-libs
       - name: Test code formatting
         run: |
           make fmt

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 PROJECT_DIR := $(shell pwd)
 BIN_DIR ?= $(PROJECT_DIR)/bin
 OUTPUT_DIR ?= $(PROJECT_DIR)/test-results
+VENV_DIR ?= $(BIN_DIR)/venv
 export TMP_DIR ?= $(OUTPUT_DIR)/tmp
-export PATH := $(BIN_DIR):$(PATH)
+export PATH := $(BIN_DIR):$(VENV_DIR)/bin:$(PATH)
 export KUBECONFIG ?= $(TMP_DIR)/kubeconfig.yaml
-export PYTHONPATH := $(BIN_DIR)/python-libs
+
+VENV := $(VENV_DIR)/touchfile #file to mark that venv is set up
 
 OS := $(shell go env GOOS)
 ARCH := $(shell go env GOARCH)
@@ -47,25 +49,25 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: lint
-lint: python-libs $(patsubst %.py,%.pylint,$(PYTHONFILES)) ## Lint Python files
+lint: $(VENV) $(patsubst %.py,%.pylint,$(PYTHONFILES)) ## Lint Python files
 
 .PHONY: fmt ## Format Python files
-fmt: python-libs
-	PYTHONPATH=$(PYTHONPATH) python3 -m black --quiet $(PYTHONFILES) $(PYTHONTESTFILES)
+fmt: $(VENV)
+	python3 -m black --quiet $(PYTHONFILES) $(PYTHONTESTFILES)
 
 ##@ Testing
 
 .PHONY: test
 test: test-nuodb-operations test-config-watcher ## Run tests
 
-test-config-watcher: test-setup python-libs
+test-config-watcher: test-setup $(VENV)
 	cd config_watcher \
-		&& PYTHONPATH=$(PYTHONPATH) python3 -m pytest \
+		&& python3 -m pytest \
 			--junitxml $(OUTPUT_DIR)/reports/config_watcher.xml
 
-test-nuodb-operations: python-libs
+test-nuodb-operations: $(VENV)
 	cd nuodb-operations \
-		&& PYTHONPATH=$(PYTHONPATH) python3 -m pytest \
+		&& python3 -m pytest \
 			--junitxml $(OUTPUT_DIR)/reports/nuodb-operations.xml
 
 test-setup: $(KWOKCTL) $(KUBECTL) ## Run tests setup
@@ -81,9 +83,10 @@ test-teardown: $(KWOKCTL) ## Run tests teardown
 docker-build: ## Build NuoDB sidecar docker image.
 	IMG_REPO="$(IMG_REPO)" IMG_TAG="$(IMG_TAG)" ./docker/build.sh
 
-.PHONY: python-libs
-python-libs: ## Download python dependencies
-	pip3 install -r nuodb-operations/test-requirements.txt -r config_watcher/test-requirements.txt -r config_watcher/requirements.txt --upgrade  -t $(PYTHONPATH)
+$(VENV): nuodb-operations/test-requirements.txt config_watcher/test-requirements.txt config_watcher/requirements.txt
+	python3 -m venv $(VENV_DIR)
+	pip3 install -r nuodb-operations/test-requirements.txt -r config_watcher/test-requirements.txt -r config_watcher/requirements.txt --ignore-installed 
+	touch $(VENV)
 
 $(KUBECTL):
 	mkdir -p bin
@@ -96,4 +99,4 @@ $(KWOKCTL):
 	chmod +x $(KWOKCTL)
 
 %.pylint:
-	PYTHONPATH=$(PYTHONPATH) $(PYLINT) $(PYLINTFLAGS) $*.py
+	$(PYLINT) $(PYLINTFLAGS) $*.py

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,9 @@ test-config-watcher: test-setup python-libs
 		&& PYTHONPATH=$(PYTHONPATH) python3 -m pytest \
 			--junitxml $(OUTPUT_DIR)/reports/config_watcher.xml
 
-test-nuodb-operations:
+test-nuodb-operations: python-libs
 	cd nuodb-operations \
-		&& python3 -m pytest \
+		&& PYTHONPATH=$(PYTHONPATH) python3 -m pytest \
 			--junitxml $(OUTPUT_DIR)/reports/nuodb-operations.xml
 
 test-setup: $(KWOKCTL) $(KUBECTL) ## Run tests setup

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ OUTPUT_DIR ?= $(PROJECT_DIR)/test-results
 export TMP_DIR ?= $(OUTPUT_DIR)/tmp
 export PATH := $(BIN_DIR):$(PATH)
 export KUBECONFIG ?= $(TMP_DIR)/kubeconfig.yaml
+export PYTHONPATH := $(BIN_DIR)/python-libs
 
 OS := $(shell go env GOOS)
 ARCH := $(shell go env GOARCH)
@@ -23,8 +24,8 @@ IMG_TAG ?= latest
 # Python linter
 PYLINT = python3 -m pylint
 PYLINTFLAGS = -rn
-PYTHONFILES := $(shell find $(PROJECT_DIR) -type f -name "*.py" -not -path "$(PROJECT_DIR)/.*/*" -not -path "*/test_*.py")
-PYTHONTESTFILES := $(shell find $(PROJECT_DIR) -type f -name "test_*.py" -not -path "$(PROJECT_DIR)/.*/*")
+PYTHONFILES := $(shell find $(PROJECT_DIR) -type f -name "*.py" -not -path "$(PROJECT_DIR)/.*/*" -not -path "*/test_*.py" -not -path "$(BIN_DIR)/*")
+PYTHONTESTFILES := $(shell find $(PROJECT_DIR) -type f -name "test_*.py" -not -path "$(PROJECT_DIR)/.*/*" -not -path "$(BIN_DIR)/*")
 
 ##@ General
 
@@ -46,20 +47,20 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: lint
-lint: $(patsubst %.py,%.pylint,$(PYTHONFILES)) ## Lint Python files
+lint: python-libs $(patsubst %.py,%.pylint,$(PYTHONFILES)) ## Lint Python files
 
 .PHONY: fmt ## Format Python files
-fmt:
-	python3 -m black --quiet $(PYTHONFILES) $(PYTHONTESTFILES)
+fmt: python-libs
+	PYTHONPATH=$(PYTHONPATH) python3 -m black --quiet $(PYTHONFILES) $(PYTHONTESTFILES)
 
 ##@ Testing
 
 .PHONY: test
 test: test-nuodb-operations test-config-watcher ## Run tests
 
-test-config-watcher: test-setup
+test-config-watcher: test-setup python-libs
 	cd config_watcher \
-		&& python3 -m pytest \
+		&& PYTHONPATH=$(PYTHONPATH) python3 -m pytest \
 			--junitxml $(OUTPUT_DIR)/reports/config_watcher.xml
 
 test-nuodb-operations:
@@ -80,6 +81,10 @@ test-teardown: $(KWOKCTL) ## Run tests teardown
 docker-build: ## Build NuoDB sidecar docker image.
 	IMG_REPO="$(IMG_REPO)" IMG_TAG="$(IMG_TAG)" ./docker/build.sh
 
+.PHONY: python-libs
+python-libs: ## Download python dependencies
+	pip3 install -r nuodb-operations/test-requirements.txt -r config_watcher/test-requirements.txt -r config_watcher/requirements.txt --upgrade  -t $(PYTHONPATH)
+
 $(KUBECTL):
 	mkdir -p bin
 	curl -L -s https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/$(OS)/$(ARCH)/kubectl -o $(KUBECTL)
@@ -91,4 +96,4 @@ $(KWOKCTL):
 	chmod +x $(KWOKCTL)
 
 %.pylint:
-	$(PYLINT) $(PYLINTFLAGS) $*.py
+	PYTHONPATH=$(PYTHONPATH) $(PYLINT) $(PYLINTFLAGS) $*.py

--- a/config_watcher/test_watcher.py
+++ b/config_watcher/test_watcher.py
@@ -148,10 +148,12 @@ class WatcherTest(unittest.TestCase):
         kwargs["env"].setdefault("LABEL_SELECTOR", self.TEST_LABEL_KEY)
         kwargs["env"].setdefault("TARGET_DIRECTORY", self.test_dir)
         kwargs["env"].setdefault("LOG", "DEBUG")
+        if "PYTHONPATH" in os.environ:
+            kwargs["env"].setdefault("PYTHONPATH", os.environ["PYTHONPATH"])
         self.watcher = self.startcmd(sys.executable, watcher_script, *args, **kwargs)
 
         try:
-            returncode = self.watcher.wait(timeout=0.5)
+            returncode = self.watcher.wait(timeout=5)
             if not expect_error:
                 # watcher failed unexpectedly
                 self.fail(f"Watcher failed [ret={returncode}]")

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -676,22 +676,16 @@ class HooksHandler(object):
 
     def log_handlers(self, indent=4):
         # Log all built-in handlers
+        builtins = list(REGISTERED_HANDLERS)
         builtin_handlers = []
         if has_archives():
-            for method, path_prefix, handler in ARCHIVE_HANDLERS:
-                path = path_prefix
-                for arg in inspect.getfullargspec(handler).args:
-                    if arg not in ["payload", "query"]:
-                        path += "/{" + arg + "}"
-                builtin_handlers.append(
-                    "{}{} /{}".format(indent * " ", method, normalize_path(path))
-                )
+            builtins += ARCHIVE_HANDLERS
         else:
             LOGGER.warning(
                 "No archive dir found, not configuring certain built-in handlers."
             )
 
-        for method, path_prefix, handler in REGISTERED_HANDLERS:
+        for method, path_prefix, handler in builtins:
             path = path_prefix
             for arg in inspect.getfullargspec(handler).args:
                 if arg not in ["payload", "query"]:

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -446,7 +446,7 @@ def create_error(exc):
     return http.HTTPStatus.INTERNAL_SERVER_ERROR, dict(success=False, message=str(exc))
 
 
-REGISTERED_HANDLERS = [
+ARCHIVE_HANDLERS = [
     ("POST", "pre-backup", pre_backup),
     ("POST", "post-backup", post_backup),
     ("GET", "metrics", lambda: REGISTRY.collect()),  # pylint: disable=W0108
@@ -480,6 +480,11 @@ def get_query_params(query_str):
 
 def normalize_path(path):
     return path[1:] if path.startswith("/") else path
+
+
+def has_archives():
+    """Check if there is an archive configured on the container."""
+    return "NUODB_ARCHIVE_DIR" in os.environ
 
 
 class ScriptHandler(object):
@@ -595,36 +600,39 @@ class RequestInfo(object):  # pylint: disable=too-few-public-methods
 
 def handle_method(req):
     # Find a handler that matches the request
-    for method, path_prefix, handler in REGISTERED_HANDLERS:
-        if req.method == method and req.components[0] == path_prefix:
-            # Make sure the correct number of parameters were supplied by
-            # inspecting method signature
-            args = req.components[1:]
-            pos_args = inspect.getfullargspec(handler).args
-            # If `payload` is in the method signature, then read the request
-            # payload as JSON and pass it at the corresponding index
-            if "payload" in pos_args:
-                try:
-                    decoded_payload = json.loads(req.payload) if req.payload else None
-                    args.insert(pos_args.index("payload"), decoded_payload)
-                except json.JSONDecodeError as e:
-                    raise UserError(  # pylint: disable=raise-missing-from
-                        "Unable to decode request payload: " + str(e)
+    if has_archives():
+        for method, path_prefix, handler in ARCHIVE_HANDLERS:
+            if req.method == method and req.components[0] == path_prefix:
+                # Make sure the correct number of parameters were supplied by
+                # inspecting method signature
+                args = req.components[1:]
+                pos_args = inspect.getfullargspec(handler).args
+                # If `payload` is in the method signature, then read the request
+                # payload as JSON and pass it at the corresponding index
+                if "payload" in pos_args:
+                    try:
+                        decoded_payload = (
+                            json.loads(req.payload) if req.payload else None
+                        )
+                        args.insert(pos_args.index("payload"), decoded_payload)
+                    except json.JSONDecodeError as e:
+                        raise UserError(  # pylint: disable=raise-missing-from
+                            "Unable to decode request payload: " + str(e)
+                        )
+                # If `query` is in the method signature, then parse the query
+                # parameters as a dictionary and pass them at the corresponding
+                # index
+                if "query" in pos_args:
+                    args.insert(pos_args.index("query"), req.query_params)
+                if len(args) != len(pos_args):
+                    msg = "{} parameter(s) expected but {} supplied in request {}".format(
+                        len(pos_args), len(args), req.parsed.path
                     )
-            # If `query` is in the method signature, then parse the query
-            # parameters as a dictionary and pass them at the corresponding
-            # index
-            if "query" in pos_args:
-                args.insert(pos_args.index("query"), req.query_params)
-            if len(args) != len(pos_args):
-                msg = "{} parameter(s) expected but {} supplied in request {}".format(
-                    len(pos_args), len(args), req.parsed.path
-                )
-                if "payload" in pos_args or "query" in pos_args:
-                    msg += ", including payload and query parameters"
-                raise UserError(msg)
-            # Request is valid. Send it to handler.
-            return path_prefix, handler(*args)
+                    if "payload" in pos_args or "query" in pos_args:
+                        msg += ", including payload and query parameters"
+                    raise UserError(msg)
+                # Request is valid. Send it to handler.
+                return path_prefix, handler(*args)
 
     # Handler was not found
     raise UserError("No handler found for path " + req.parsed.path)
@@ -664,15 +672,21 @@ class HooksHandler(object):
     def log_handlers(self, indent=4):
         # Log all built-in handlers
         builtin_handlers = []
-        for method, path_prefix, handler in REGISTERED_HANDLERS:
-            path = path_prefix
-            for arg in inspect.getfullargspec(handler).args:
-                if arg not in ["payload", "query"]:
-                    path += "/{" + arg + "}"
-            builtin_handlers.append(
-                "{}{} /{}".format(indent * " ", method, normalize_path(path))
+        if has_archives():
+            for method, path_prefix, handler in ARCHIVE_HANDLERS:
+                path = path_prefix
+                for arg in inspect.getfullargspec(handler).args:
+                    if arg not in ["payload", "query"]:
+                        path += "/{" + arg + "}"
+                builtin_handlers.append(
+                    "{}{} /{}".format(indent * " ", method, normalize_path(path))
+                )
+        else:
+            LOGGER.warning(
+                "No archive dir found, not configuring certain built-in handlers."
             )
-        LOGGER.info("Built-in handlers:\n%s", "\n".join(builtin_handlers))
+        if builtin_handlers:
+            LOGGER.info("Built-in handlers:\n%s", "\n".join(builtin_handlers))
         # Log all custom handlers, if there are any
         custom_handlers = []
         for handler in self.handlers:

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -449,6 +449,9 @@ def create_error(exc):
 ARCHIVE_HANDLERS = [
     ("POST", "pre-backup", pre_backup),
     ("POST", "post-backup", post_backup),
+]
+
+REGISTERED_HANDLERS = [
     ("GET", "metrics", lambda: REGISTRY.collect()),  # pylint: disable=W0108
 ]
 
@@ -600,39 +603,40 @@ class RequestInfo(object):  # pylint: disable=too-few-public-methods
 
 def handle_method(req):
     # Find a handler that matches the request
+    handlers = list(REGISTERED_HANDLERS)
     if has_archives():
-        for method, path_prefix, handler in ARCHIVE_HANDLERS:
-            if req.method == method and req.components[0] == path_prefix:
-                # Make sure the correct number of parameters were supplied by
-                # inspecting method signature
-                args = req.components[1:]
-                pos_args = inspect.getfullargspec(handler).args
-                # If `payload` is in the method signature, then read the request
-                # payload as JSON and pass it at the corresponding index
-                if "payload" in pos_args:
-                    try:
-                        decoded_payload = (
-                            json.loads(req.payload) if req.payload else None
-                        )
-                        args.insert(pos_args.index("payload"), decoded_payload)
-                    except json.JSONDecodeError as e:
-                        raise UserError(  # pylint: disable=raise-missing-from
-                            "Unable to decode request payload: " + str(e)
-                        )
-                # If `query` is in the method signature, then parse the query
-                # parameters as a dictionary and pass them at the corresponding
-                # index
-                if "query" in pos_args:
-                    args.insert(pos_args.index("query"), req.query_params)
-                if len(args) != len(pos_args):
-                    msg = "{} parameter(s) expected but {} supplied in request {}".format(
-                        len(pos_args), len(args), req.parsed.path
+        handlers += ARCHIVE_HANDLERS
+
+    for method, path_prefix, handler in handlers:
+        if req.method == method and req.components[0] == path_prefix:
+            # Make sure the correct number of parameters were supplied by
+            # inspecting method signature
+            args = req.components[1:]
+            pos_args = inspect.getfullargspec(handler).args
+            # If `payload` is in the method signature, then read the request
+            # payload as JSON and pass it at the corresponding index
+            if "payload" in pos_args:
+                try:
+                    decoded_payload = json.loads(req.payload) if req.payload else None
+                    args.insert(pos_args.index("payload"), decoded_payload)
+                except json.JSONDecodeError as e:
+                    raise UserError(  # pylint: disable=raise-missing-from
+                        "Unable to decode request payload: " + str(e)
                     )
-                    if "payload" in pos_args or "query" in pos_args:
-                        msg += ", including payload and query parameters"
-                    raise UserError(msg)
-                # Request is valid. Send it to handler.
-                return path_prefix, handler(*args)
+            # If `query` is in the method signature, then parse the query
+            # parameters as a dictionary and pass them at the corresponding
+            # index
+            if "query" in pos_args:
+                args.insert(pos_args.index("query"), req.query_params)
+            if len(args) != len(pos_args):
+                msg = "{} parameter(s) expected but {} supplied in request {}".format(
+                    len(pos_args), len(args), req.parsed.path
+                )
+                if "payload" in pos_args or "query" in pos_args:
+                    msg += ", including payload and query parameters"
+                raise UserError(msg)
+            # Request is valid. Send it to handler.
+            return path_prefix, handler(*args)
 
     # Handler was not found
     raise UserError("No handler found for path " + req.parsed.path)
@@ -661,13 +665,14 @@ class HooksHandler(object):
         self.handlers = read_handler_config(handler_config)
         self.log_handlers()
         # Register metric functions
-        VOLUME_AVAILABLE_BYTES.labels("archive-volume").set_function(
-            lambda: disk_usage(ARCHIVE_DIR)[2]
-        )
-        if JOURNAL_DIR:
-            VOLUME_AVAILABLE_BYTES.labels("journal-volume").set_function(
-                lambda: disk_usage(JOURNAL_DIR)[2]
+        if has_archives():
+            VOLUME_AVAILABLE_BYTES.labels("archive-volume").set_function(
+                lambda: disk_usage(ARCHIVE_DIR)[2]
             )
+            if JOURNAL_DIR:
+                VOLUME_AVAILABLE_BYTES.labels("journal-volume").set_function(
+                    lambda: disk_usage(JOURNAL_DIR)[2]
+                )
 
     def log_handlers(self, indent=4):
         # Log all built-in handlers
@@ -685,8 +690,19 @@ class HooksHandler(object):
             LOGGER.warning(
                 "No archive dir found, not configuring certain built-in handlers."
             )
+
+        for method, path_prefix, handler in REGISTERED_HANDLERS:
+            path = path_prefix
+            for arg in inspect.getfullargspec(handler).args:
+                if arg not in ["payload", "query"]:
+                    path += "/{" + arg + "}"
+            builtin_handlers.append(
+                "{}{} /{}".format(indent * " ", method, normalize_path(path))
+            )
         if builtin_handlers:
             LOGGER.info("Built-in handlers:\n%s", "\n".join(builtin_handlers))
+        else:
+            LOGGER.info("No built-in handlers registered")
         # Log all custom handlers, if there are any
         custom_handlers = []
         for handler in self.handlers:

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -446,12 +446,12 @@ def create_error(exc):
     return http.HTTPStatus.INTERNAL_SERVER_ERROR, dict(success=False, message=str(exc))
 
 
-ARCHIVE_HANDLERS = [
+SM_HANDLERS = [
     ("POST", "pre-backup", pre_backup),
     ("POST", "post-backup", post_backup),
 ]
 
-REGISTERED_HANDLERS = [
+COMMON_HANDLERS = [
     ("GET", "metrics", lambda: REGISTRY.collect()),  # pylint: disable=W0108
 ]
 
@@ -485,9 +485,16 @@ def normalize_path(path):
     return path[1:] if path.startswith("/") else path
 
 
-def has_archives():
+def has_archive():
     """Check if there is an archive configured on the container."""
     return "NUODB_ARCHIVE_DIR" in os.environ
+
+
+def get_builtin_handlers():
+    handlers = list(COMMON_HANDLERS)
+    if has_archive():
+        handlers += SM_HANDLERS
+    return handlers
 
 
 class ScriptHandler(object):
@@ -603,11 +610,7 @@ class RequestInfo(object):  # pylint: disable=too-few-public-methods
 
 def handle_method(req):
     # Find a handler that matches the request
-    handlers = list(REGISTERED_HANDLERS)
-    if has_archives():
-        handlers += ARCHIVE_HANDLERS
-
-    for method, path_prefix, handler in handlers:
+    for method, path_prefix, handler in get_builtin_handlers():
         if req.method == method and req.components[0] == path_prefix:
             # Make sure the correct number of parameters were supplied by
             # inspecting method signature
@@ -665,7 +668,7 @@ class HooksHandler(object):
         self.handlers = read_handler_config(handler_config)
         self.log_handlers()
         # Register metric functions
-        if has_archives():
+        if has_archive():
             VOLUME_AVAILABLE_BYTES.labels("archive-volume").set_function(
                 lambda: disk_usage(ARCHIVE_DIR)[2]
             )
@@ -676,16 +679,13 @@ class HooksHandler(object):
 
     def log_handlers(self, indent=4):
         # Log all built-in handlers
-        builtins = list(REGISTERED_HANDLERS)
         builtin_handlers = []
-        if has_archives():
-            builtins += ARCHIVE_HANDLERS
-        else:
+        if not has_archive():
             LOGGER.warning(
                 "No archive dir found, not configuring certain built-in handlers."
             )
 
-        for method, path_prefix, handler in builtins:
+        for method, path_prefix, handler in get_builtin_handlers():
             path = path_prefix
             for arg in inspect.getfullargspec(handler).args:
                 if arg not in ["payload", "query"]:
@@ -799,7 +799,7 @@ def main():
     if args.subcommand == "server":
         start_server(args.port, args.handler_config)
     if args.subcommand == "pre-hook":
-        if not has_archives():
+        if not has_archive():
             raise RuntimeError("No archive path configured on this container")
         # read opaque data and pass it to pre-hook
         opaque = None
@@ -807,7 +807,7 @@ def main():
             opaque = args.opaque_file.read()
         pre_backup(args.backup_id, dict(opaque=opaque, timeout=args.timeout))
     elif args.subcommand == "post-hook":
-        if not has_archives():
+        if not has_archive():
             raise RuntimeError("No archive path configured on this container")
         post_backup(args.backup_id, dict(force=args.force))
 

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -789,12 +789,16 @@ def main():
     if args.subcommand == "server":
         start_server(args.port, args.handler_config)
     if args.subcommand == "pre-hook":
+        if not has_archives():
+            raise RuntimeError("No archive path configured on this container")
         # read opaque data and pass it to pre-hook
         opaque = None
         if args.opaque_file:
             opaque = args.opaque_file.read()
         pre_backup(args.backup_id, dict(opaque=opaque, timeout=args.timeout))
     elif args.subcommand == "post-hook":
+        if not has_archives():
+            raise RuntimeError("No archive path configured on this container")
         post_backup(args.backup_id, dict(force=args.force))
 
 

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -173,6 +173,100 @@ class WebHooksTest(unittest.TestCase):
         finally:
             conn.close()
 
+    @ConfigOverrides(
+        custom_handlers=[
+            {
+                "method": "GET",
+                "path": "/exit",
+                "script": "exit ${code:=0}",
+                "statusMappings": {"1": 500, "2": 400},
+            }
+        ]
+    )
+    def testMetrics(self):
+        # request metrics endpoint
+        resp, data = self.request(method="GET", path="/metrics")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        out = data.decode("utf-8")
+
+        # request metrics endpoint again
+        resp, data = self.request(method="GET", path="/metrics")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        out = data.decode("utf-8")
+
+        # verify that hook request latency Histogram is emitted
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="1.0",method="GET",endpoint="/metrics",http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/metrics",http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/metrics",http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_count{method="GET",endpoint="/metrics",http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_sum{method="GET",endpoint="/metrics",http_status="200"}',
+            out,
+        )
+
+        # request custom handler
+        resp, data = self.request(method="GET", path="/exit")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        resp, data = self.request(method="GET", path="/exit?code=1")
+        self.assertEqual(http.HTTPStatus.INTERNAL_SERVER_ERROR, resp.status, str(data))
+        resp, data = self.request(method="GET", path="/exit?code=2")
+        self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status, str(data))
+
+        # request metrics endpoint again
+        resp, data = self.request(method="GET", path="/metrics")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        out = data.decode("utf-8")
+
+        # verify that hook request latency Histogram is emitted
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="200"}',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="500"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="500"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="500"}',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="400"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="400"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="400"}',
+            out,
+        )
+
 
 class BackupHooksTest(WebHooksTest):
 
@@ -291,7 +385,7 @@ class BackupHooksTest(WebHooksTest):
             }
         ]
     )
-    def testMetrics(self):
+    def testBackupHookMetrics(self):
         # request metrics endpoint
         resp, data = self.request(method="GET", path="/metrics")
         self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
@@ -309,33 +403,6 @@ class BackupHooksTest(WebHooksTest):
             self.assertNotIn(
                 'nuodb_volume_available_bytes{volume="journal-volume"}', out
             )
-
-        # request metrics endpoint again
-        resp, data = self.request(method="GET", path="/metrics")
-        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
-        out = data.decode("utf-8")
-
-        # verify that hook request latency Histogram is emitted
-        self.assertIn(
-            'hook_request_duration_seconds_bucket{le="1.0",method="GET",endpoint="/metrics",http_status="200"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/metrics",http_status="200"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/metrics",http_status="200"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_count{method="GET",endpoint="/metrics",http_status="200"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_sum{method="GET",endpoint="/metrics",http_status="200"}',
-            out,
-        )
 
         # call backup hooks
         backup_id = str(uuid.uuid4())
@@ -357,57 +424,6 @@ class BackupHooksTest(WebHooksTest):
         self.assertIn("snapshot_backup_duration_seconds_count 1", out)
         self.assertIn("snapshot_backup_duration_seconds_sum", out)
         self.assertNotIn("snapshot_backup_duration_seconds 0", out)
-
-        # request custom handler
-        resp, data = self.request(method="GET", path="/exit")
-        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
-        resp, data = self.request(method="GET", path="/exit?code=1")
-        self.assertEqual(http.HTTPStatus.INTERNAL_SERVER_ERROR, resp.status, str(data))
-        resp, data = self.request(method="GET", path="/exit?code=2")
-        self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status, str(data))
-
-        # request metrics endpoint again
-        resp, data = self.request(method="GET", path="/metrics")
-        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
-        out = data.decode("utf-8")
-
-        # verify that hook request latency Histogram is emitted
-        self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="200"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="200"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="200"}',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="500"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="500"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="500"}',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="400"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="400"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="400"}',
-            out,
-        )
 
 
 class BackupHooksExternalJournalTest(BackupHooksTest):
@@ -454,17 +470,7 @@ class NoArchivesHandlersTest(WebHooksTest):
         self.assertFalse(data["success"])
         self.assertIn("No handler found for path /post-backup/", data["message"])
 
-    @ConfigOverrides(
-        custom_handlers=[
-            {
-                "method": "GET",
-                "path": "/exit",
-                "script": "exit ${code:=0}",
-                "statusMappings": {"1": 500, "2": 400},
-            }
-        ]
-    )
-    def testMetrics(self):
+    def testNoArchiveMetrics(self):
         # request metrics endpoint
         resp, data = self.request(method="GET", path="/metrics")
         self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
@@ -474,84 +480,6 @@ class NoArchivesHandlersTest(WebHooksTest):
         self.assertNotIn('nuodb_volume_available_bytes{volume="archive-volume"}', out)
 
         self.assertNotIn('nuodb_volume_available_bytes{volume="journal-volume"}', out)
-
-        # request metrics endpoint again
-        resp, data = self.request(method="GET", path="/metrics")
-        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
-        out = data.decode("utf-8")
-
-        # verify that hook request latency Histogram is emitted
-        self.assertIn(
-            'hook_request_duration_seconds_bucket{le="1.0",method="GET",endpoint="/metrics",http_status="200"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/metrics",http_status="200"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/metrics",http_status="200"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_count{method="GET",endpoint="/metrics",http_status="200"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_sum{method="GET",endpoint="/metrics",http_status="200"}',
-            out,
-        )
-
-        # request custom handler
-        resp, data = self.request(method="GET", path="/exit")
-        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
-        resp, data = self.request(method="GET", path="/exit?code=1")
-        self.assertEqual(http.HTTPStatus.INTERNAL_SERVER_ERROR, resp.status, str(data))
-        resp, data = self.request(method="GET", path="/exit?code=2")
-        self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status, str(data))
-
-        # request metrics endpoint again
-        resp, data = self.request(method="GET", path="/metrics")
-        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
-        out = data.decode("utf-8")
-
-        # verify that hook request latency Histogram is emitted
-        self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="200"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="200"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="200"}',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="500"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="500"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="500"}',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="400"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="400"} 1',
-            out,
-        )
-        self.assertIn(
-            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="400"}',
-            out,
-        )
 
 
 class CliTests(unittest.TestCase):

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -48,7 +48,7 @@ class ConfigOverrides(object):
         return testMethod
 
 
-class WebHooksTest(unittest.TestCase):
+class HttpHandlersTests(unittest.TestCase):
     hooks_dir = os.path.dirname(os.path.abspath(__file__))
     test_results_dir = os.path.join(
         os.path.dirname(hooks_dir), "test-results", "nuodb-operations"
@@ -268,7 +268,7 @@ class WebHooksTest(unittest.TestCase):
         )
 
 
-class BackupHooksTest(WebHooksTest):
+class BackupHooksTest(HttpHandlersTests):
 
     def path(self, *args):
         return os.path.join(self.test_dir, *args)
@@ -443,7 +443,7 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
         self.freeze_archive_patch.stop()
 
 
-class NoArchivesHandlersTest(WebHooksTest):
+class NoArchivesHandlersTest(HttpHandlersTests):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -14,6 +14,8 @@ import http
 from http.client import HTTPConnection
 from threading import Thread
 from wsgiref.simple_server import make_server
+import sys
+import shlex
 
 import metrics
 import backup_hooks
@@ -46,14 +48,11 @@ class ConfigOverrides(object):
         return testMethod
 
 
-class BackupHooksTest(unittest.TestCase):
+class WebHooksTest(unittest.TestCase):
     hooks_dir = os.path.dirname(os.path.abspath(__file__))
     test_results_dir = os.path.join(
         os.path.dirname(hooks_dir), "test-results", "nuodb-operations"
     )
-
-    def path(self, *args):
-        return os.path.join(self.test_dir, *args)
 
     @classmethod
     def setUpClass(cls):
@@ -84,9 +83,10 @@ class BackupHooksTest(unittest.TestCase):
     def configure_server(self):
         server_config = self.get_server_config()
         # Configure environment variables
-        self.archive_dir = os.path.join(self.test_dir, "archive")
-        os.makedirs(self.archive_dir)
-        os.environ["NUODB_ARCHIVE_DIR"] = self.archive_dir
+        if server_config.get("has_archives", True):
+            self.archive_dir = os.path.join(self.test_dir, "archive")
+            os.makedirs(self.archive_dir)
+            os.environ["NUODB_ARCHIVE_DIR"] = self.archive_dir
         if server_config.get("external_journal", False):
             self.journal_dir = os.path.join(self.test_dir, "journal")
             os.makedirs(self.journal_dir)
@@ -105,16 +105,6 @@ class BackupHooksTest(unittest.TestCase):
         self.mock_functions()
         return handler_config
 
-    def mock_functions(self):
-        server_config = self.get_server_config()
-        nuodb_processes = server_config.get(
-            "nuodb_processes", [{"pid": 1234, "sid": 0}]
-        )
-        self.nuodb_processes_patch = mock.patch(
-            "backup_hooks.get_nuodb_process_info", return_value=nuodb_processes
-        )
-        self.nuodb_processes_mock = self.nuodb_processes_patch.start()
-
     def setUp(self):
         # Create test tmp directory
         self.test_dir = os.path.join(self.tmp_dir, self._testMethodName)
@@ -124,9 +114,11 @@ class BackupHooksTest(unittest.TestCase):
         self.start_server()
         self._wait_until_ready()
 
+    def mock_functions(self):
+        pass
+
     def tearDown(self):
         self.stop_server()
-        self.nuodb_processes_patch.stop()
         # Restore environment variables
         os.environ.clear()
         os.environ.update(self.original_env)
@@ -180,6 +172,26 @@ class BackupHooksTest(unittest.TestCase):
             return resp, data
         finally:
             conn.close()
+
+
+class BackupHooksTest(WebHooksTest):
+
+    def path(self, *args):
+        return os.path.join(self.test_dir, *args)
+
+    def mock_functions(self):
+        server_config = self.get_server_config()
+        nuodb_processes = server_config.get(
+            "nuodb_processes", [{"pid": 1234, "sid": 0}]
+        )
+        self.nuodb_processes_patch = mock.patch(
+            "backup_hooks.get_nuodb_process_info", return_value=nuodb_processes
+        )
+        self.nuodb_processes_mock = self.nuodb_processes_patch.start()
+
+    def tearDown(self):
+        self.nuodb_processes_patch.stop()
+        super().tearDown()
 
     def pre_backup(self, backup_id, opaque=None):
         resp, data = self.request(
@@ -413,6 +425,164 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
     def tearDown(self):
         super().tearDown()
         self.freeze_archive_patch.stop()
+
+
+class NoArchivesHandlersTest(WebHooksTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.server_config = dict(has_archives=False)
+
+    def testNoHooks(self):
+        resp, data = self.request(
+            method="POST",
+            path=f"/pre-backup/{uuid.uuid4()}",
+            body=None,
+            headers={"Content-Type": "application/json"},
+        )
+        data = json.loads(data)
+        self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status, str(data))
+        self.assertFalse(data["success"])
+        self.assertIn("No handler found for path /pre-backup/", data["message"])
+
+        resp, data = self.request(
+            method="POST",
+            path=f"/post-backup/{uuid.uuid4()}",
+        )
+        data = json.loads(data)
+        self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status, str(data))
+        self.assertFalse(data["success"])
+        self.assertIn("No handler found for path /post-backup/", data["message"])
+
+    @ConfigOverrides(
+        custom_handlers=[
+            {
+                "method": "GET",
+                "path": "/exit",
+                "script": "exit ${code:=0}",
+                "statusMappings": {"1": 500, "2": 400},
+            }
+        ]
+    )
+    def testMetrics(self):
+        # request metrics endpoint
+        resp, data = self.request(method="GET", path="/metrics")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        out = data.decode("utf-8")
+
+        # verify that volume metrics are reported
+        self.assertNotIn('nuodb_volume_available_bytes{volume="archive-volume"}', out)
+
+        self.assertNotIn('nuodb_volume_available_bytes{volume="journal-volume"}', out)
+
+        # request metrics endpoint again
+        resp, data = self.request(method="GET", path="/metrics")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        out = data.decode("utf-8")
+
+        # verify that hook request latency Histogram is emitted
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="1.0",method="GET",endpoint="/metrics",http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/metrics",http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/metrics",http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_count{method="GET",endpoint="/metrics",http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_sum{method="GET",endpoint="/metrics",http_status="200"}',
+            out,
+        )
+
+        # request custom handler
+        resp, data = self.request(method="GET", path="/exit")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        resp, data = self.request(method="GET", path="/exit?code=1")
+        self.assertEqual(http.HTTPStatus.INTERNAL_SERVER_ERROR, resp.status, str(data))
+        resp, data = self.request(method="GET", path="/exit?code=2")
+        self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status, str(data))
+
+        # request metrics endpoint again
+        resp, data = self.request(method="GET", path="/metrics")
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        out = data.decode("utf-8")
+
+        # verify that hook request latency Histogram is emitted
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="200"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="200"}',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="500"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="500"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="500"}',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_bucket{le="+Inf",method="GET",endpoint="/exit",http_status="400"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_count{method="GET",endpoint="/exit",http_status="400"} 1',
+            out,
+        )
+        self.assertIn(
+            'hook_request_duration_seconds_sum{method="GET",endpoint="/exit",http_status="400"}',
+            out,
+        )
+
+
+class CliTests(unittest.TestCase):
+    def testNoArchives(self):
+        "Test CLI options that should be disabled if no archive directory is configured"
+        with mock.patch.dict("os.environ") as mockenv:
+            mockenv.pop("NUODB_ARCHIVE_DIR", None)
+
+            with mock.patch.object(
+                sys,
+                "argv",
+                shlex.split("backup_hooks.py pre-hook --backup-id not-needed"),
+            ):
+                mockenv.pop("NUODB_ARCHIVE_DIR", None)
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    "No archive path configured on this container",
+                    backup_hooks.main,
+                )
+
+            with mock.patch.object(
+                sys,
+                "argv",
+                shlex.split("backup_hooks.py post-hook --backup-id not-needed"),
+            ):
+                mockenv.pop("NUODB_ARCHIVE_DIR", None)
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    "No archive path configured on this container",
+                    backup_hooks.main,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If there is no archive directory set (because this is a sidecar to a TE) do not configure the `pre-backup` and `post-backup` hooks, collect volume usage metrics, or allow `pre-hook` and `post-hook` cli commands.

Also added `python-libs` make target to install python dependencies into the workspace and changed python targets to use it.

Testing done:
- `make test`
- Used an updated sidecar image in local testing of the TE Helm chart (PR in progress)