### PR TITLE
Avoid scheduling cancellation when freeze is not used

### DIFF
--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -402,7 +402,7 @@ def get_backup_timeout(payload):
             return int(payload.get("timeout"))
         except ValueError as e:
             raise UserError("Invalid request timeout") from e
-    if FREEZE_TIMEOUT:
+    if FREEZE_TIMEOUT and JOURNAL_DIR:
         return int(FREEZE_TIMEOUT)
 
 


### PR DESCRIPTION
This change suppresses cancellation of freeze if the journal directory is on the same volume as the archive directory, which does not require writes to the archive to be frozen.