### PR TITLE
Added backup cancelation policy

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -348,7 +348,7 @@ indent-string='    '
 max-line-length=100
 
 # Maximum number of lines in a module.
-max-module-lines=1000
+max-module-lines=1500
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ docker-build: ## Build NuoDB sidecar docker image.
 
 $(VENV): nuodb-operations/test-requirements.txt config_watcher/test-requirements.txt config_watcher/requirements.txt
 	python3 -m venv $(VENV_DIR)
-	pip3 install \
+	$(VENV_DIR)/bin/python3 -m pip install \
 		-r nuodb-operations/requirements.txt \
 		-r nuodb-operations/test-requirements.txt \
 		-r config_watcher/test-requirements.txt \

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -10,7 +10,7 @@ import sys
 import time
 import urllib
 import wsgiref.util
-from threading import Lock, Timer, Thread
+from threading import Lock, Timer, Thread, Event
 from shutil import which, disk_usage
 import operator
 import copy
@@ -309,28 +309,14 @@ def pre_backup(backup_id, payload):
         if JOURNAL_DIR is not None:
             freeze_archive(backup_id, processes, timeout=timeout)
 
-        # Cancel backup operation prematurely
-        schedule_cancellation(backup_id, timeout)
-
-
-def cancel_backup(backup_id, reason):
-    try:
-        current_backup_id = get_backup_id()
-        if current_backup_id and current_backup_id == backup_id:
-            LOGGER.warning(
-                "Canceling backup with ID %s: %s",
-                backup_id,
-                reason,
-            )
-            post_backup(backup_id, query={})
-    except ArchivingNotPausedError:
-        # Suppress this error during backup cancellation
-        pass
+        # Schedule cancelation for the backup operation
+        CancelationPolicy.apply(backup_id, timeout=timeout)
 
 
 class CancelationPolicy:
     _lock = Lock()
     _rules = None
+    _threads = []
 
     @classmethod
     def load(cls, policy_config):
@@ -349,11 +335,12 @@ class CancelationPolicy:
             return []
 
     @classmethod
-    def apply(cls, backup_id, interval=CANCELATION_POLICY_INTERVAL):
+    def apply(cls, backup_id, interval=CANCELATION_POLICY_INTERVAL, timeout=None):
         rules = cls.rules()
+        stop_event = Event()
 
-        def monitor():
-            while get_backup_id() == backup_id:
+        def monitor_rules():
+            while get_backup_id() == backup_id and not stop_event.is_set():
                 errors = []
                 for rule in rules:
                     err_msg = rule.evaluate()
@@ -361,13 +348,53 @@ class CancelationPolicy:
                         errors.append(err_msg)
                 if len(errors) > 0:
                     # some of the rules are satisfied so cancel the backup operation
-                    cancel_backup(backup_id, "; ".join(errors))
+                    cls.cancel_backup(backup_id, "; ".join(errors))
                     break
-                time.sleep(interval)
+                stop_event.wait(interval)
             LOGGER.debug("Stopped monitoring backup %s", backup_id)
 
+        threads = []
         if len(rules) > 0:
-            Thread(target=monitor, daemon=True).start()
+            # schedule cancelation based on rules
+            thread = Thread(target=monitor_rules, daemon=True)
+            thread.start()
+            threads.append((thread, stop_event.set))
+        if timeout and timeout > 0:
+            # schedule cancelation based on timeout
+            timer = Timer(
+                timeout,
+                lambda: cls.cancel_backup(backup_id, f"Timeout after {timeout}s."),
+            )
+            timer.start()
+            threads.append((timer, lambda: timer.cancel))
+        if threads:
+            with cls._lock:
+                cls._threads = threads
+
+    @classmethod
+    def cancel_backup(cls, backup_id, reason):
+        try:
+            current_backup_id = get_backup_id()
+            if current_backup_id and current_backup_id == backup_id:
+                LOGGER.warning(
+                    "Canceling backup with ID %s: %s",
+                    backup_id,
+                    reason,
+                )
+                _post_backup(backup_id, query={}, is_canceled=True)
+        except ArchivingNotPausedError:
+            # Suppress this error during backup cancellation
+            pass
+
+    @classmethod
+    def stop(cls, backup_id, timeout=None):
+        with cls._lock:
+            if cls._threads:
+                while cls._threads:
+                    thread, stop_fn = cls._threads.pop()
+                    stop_fn()
+                    thread.join(timeout=timeout)
+                LOGGER.debug("Stopped cancelation policy for backup %s", backup_id)
 
     @staticmethod
     def parse(policy_config):
@@ -494,17 +521,7 @@ class ScriptCancelationRule(CancelationRule):
         return float(out.decode("utf-8"))
 
 
-def schedule_cancellation(backup_id, timeout=None):
-    if timeout and timeout > 0:
-        # schedule cancelation based on timeout
-        Timer(
-            timeout, lambda: cancel_backup(backup_id, f"Timeout after {timeout}s.")
-        ).start()
-    # schedule cancelation based on configured policy
-    CancelationPolicy.apply(backup_id)
-
-
-def post_backup(backup_id, query):
+def _post_backup(backup_id, query, is_canceled=False):
     # Check that backup ID was specified
     if not backup_id:
         raise UserError("Backup ID not specified")
@@ -530,6 +547,10 @@ def post_backup(backup_id, query):
         if not processes:
             raise RuntimeError("No nuodb process found")
 
+        if not is_canceled:
+            # stop the cancelation policy if one is running for this backup ID
+            CancelationPolicy.stop(backup_id, timeout=60)
+
         # If the archive and journal are on separate volumes, we must unblock
         # writes to the archive
         if JOURNAL_DIR is not None:
@@ -549,6 +570,10 @@ def post_backup(backup_id, query):
         # Record the total duration of the snapshot operation
         if ctime:
             BACKUP_DURATION_SECONDS.observe(time.time() - ctime)
+
+
+def post_backup(backup_id, query):
+    _post_backup(backup_id, query)
 
 
 def remove_backup_files():

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -323,7 +323,14 @@ class CancelationPolicy:
         rules = cls.parse(policy_config)
         if not rules and JOURNAL_DIR is not None:
             # add default cancelation rules
-            rules.append(JournalUtilizationRule.from_dict(op=">", threshold=80))
+            rules.append(
+                JournalUtilizationRule.from_dict(
+                    type="journalUtilization",
+                    op=">",
+                    threshold=80,
+                    duration=60,
+                )
+            )
         with cls._lock:
             cls._rules = rules
 
@@ -366,7 +373,7 @@ class CancelationPolicy:
                 lambda: cls.cancel_backup(backup_id, f"Timeout after {timeout}s."),
             )
             timer.start()
-            threads.append((timer, lambda: timer.cancel))
+            threads.append((timer, timer.cancel))
         if threads:
             with cls._lock:
                 cls._threads = threads
@@ -374,27 +381,35 @@ class CancelationPolicy:
     @classmethod
     def cancel_backup(cls, backup_id, reason):
         try:
-            current_backup_id = get_backup_id()
-            if current_backup_id and current_backup_id == backup_id:
-                LOGGER.warning(
-                    "Canceling backup with ID %s: %s",
-                    backup_id,
-                    reason,
-                )
-                _post_backup(backup_id, query={}, is_canceled=True)
+            with cls._lock:
+                current_backup_id = get_backup_id()
+                if current_backup_id and current_backup_id == backup_id:
+                    LOGGER.warning(
+                        "Canceling backup with ID %s: %s",
+                        backup_id,
+                        reason,
+                    )
+                    _post_backup(backup_id, query={}, is_canceled=True)
         except ArchivingNotPausedError:
             # Suppress this error during backup cancellation
             pass
+        finally:
+            # stop all policy threads without waiting
+            cls.stop(backup_id)
 
     @classmethod
     def stop(cls, backup_id, timeout=None):
+        wait_for = []
         with cls._lock:
-            if cls._threads:
-                while cls._threads:
-                    thread, stop_fn = cls._threads.pop()
-                    stop_fn()
-                    thread.join(timeout=timeout)
-                LOGGER.debug("Stopped cancelation policy for backup %s", backup_id)
+            while cls._threads:
+                thread, stop_fn = cls._threads.pop()
+                stop_fn()
+                wait_for.append(thread)
+        if timeout and timeout > 0:
+            # wait for all policy threads
+            for thread in wait_for:
+                thread.join(timeout=timeout)
+        LOGGER.debug("Stopped cancelation policy for backup %s", backup_id)
 
     @staticmethod
     def parse(policy_config):
@@ -409,20 +424,18 @@ class CancelationPolicy:
             rules = []
             with open(policy_config) as f:
                 config_data = json.loads(f.read())
-                rules_list = config_data.get("rules")
-                if rules_list:
-                    for rule in rules_list:
-                        rule_type = rule.get("type")
-                        if rule_type == "script":
-                            rules.append(ScriptCancelationRule.from_dict(**rule))
-                        elif (
-                            rule_type == "journalUtilization"
-                            and JOURNAL_DIR is not None
-                        ):
-                            rules.append(JournalUtilizationRule.from_dict(**rule))
-                        else:
-                            LOGGER.info(
-                                "Ignoring unknown policy rule type=%s", rule_type
+                rules_cfg = config_data.get("rules")
+                if rules_cfg:
+                    all_rules = CancelationRule.subclasses()
+                    for rule_config in rules_cfg:
+                        try:
+                            for cls in all_rules:
+                                rule = cls.from_dict(**rule_config)
+                                if rule:
+                                    rules.append(rule)
+                        except Exception:
+                            LOGGER.exception(
+                                "Ignoring invalid policy rule %s", rule_config
                             )
             return rules
         except Exception:
@@ -444,6 +457,7 @@ OPS = {
 
 class CancelationRule:
 
+    RULE_TYPE = None
     MSG_FMT = "{rule.name} value {value:.2f} is {rule.op} {rule.threshold} for more than {rule.duration}s"  # pylint: disable=line-too-long
 
     def __init__(
@@ -479,14 +493,31 @@ class CancelationRule:
             )
 
     @classmethod
+    def subclasses(cls):
+        seen = set()
+        queue = [cls]
+        while queue:
+            parent = queue.pop()
+            for child in parent.__subclasses__():
+                if child not in seen:
+                    seen.add(child)
+                    queue.append(child)
+        return seen
+
+    @classmethod
     def from_dict(cls, **kwargs):
-        name = kwargs.pop("name")
-        op = kwargs.pop("op")
-        threshold = kwargs.pop("threshold")
-        return cls(name, op, threshold, **kwargs)
+        """Returns an optional rule implementation based on its type."""
+        rule_type = kwargs.pop("type")
+        if cls.RULE_TYPE and cls.RULE_TYPE == rule_type:
+            name = kwargs.pop("name")
+            op = kwargs.pop("op")
+            threshold = kwargs.pop("threshold")
+            return cls(name, op, threshold, **kwargs)
 
 
 class JournalUtilizationRule(CancelationRule):
+
+    RULE_TYPE = "journalUtilization"
 
     def apply(self, **kwargs):
         if JOURNAL_DIR is not None:
@@ -496,12 +527,13 @@ class JournalUtilizationRule(CancelationRule):
 
     @classmethod
     def from_dict(cls, **kwargs):
-        op = kwargs.pop("op")
-        threshold = kwargs.pop("threshold")
-        return cls("Journal volume utilization percentage", op, threshold, **kwargs)
+        default_name = "Journal volume utilization percentage"
+        return super().from_dict(**{"name": default_name, **kwargs})
 
 
 class ScriptCancelationRule(CancelationRule):
+
+    RULE_TYPE = "script"
 
     def __init__(
         self, name, op, threshold, script, duration=None, timeout=60, **kwargs

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -12,6 +12,8 @@ import urllib
 import wsgiref.util
 from threading import Lock, Timer, Thread
 from shutil import which, disk_usage
+import operator
+import copy
 
 import werkzeug
 
@@ -27,15 +29,11 @@ JOURNAL_DIR = os.environ.get("NUODB_JOURNAL_DIR")
 FREEZE_MODE = os.environ.get("FREEZE_MODE")
 FREEZE_TIMEOUT = os.environ.get("FREEZE_TIMEOUT")
 
-MAX_JOURNAL_PERCENT_THRESHOLD = float(
-    os.environ.get("MAX_JOURNAL_PERCENT_THRESHOLD", 80)
-)
-MAX_JOURNAL_DURATION = int(os.environ.get("MAX_JOURNAL_DURATION", 30))
-MAX_JOURNAL_INTERVAL = int(os.environ.get("MAX_JOURNAL_INTERVAL", 5))
-
 MODE_HOTSNAP = "hotsnap"
 MODE_FSFREEZE = "fsfreeze"
 MODE_SUSPEND = "suspend"
+
+CANCELATION_POLICY_INTERVAL = int(os.environ.get("CANCELATION_POLICY_INTERVAL", 5))
 
 
 def from_dir(base_dir, *args):
@@ -320,7 +318,7 @@ def cancel_backup(backup_id, reason):
         current_backup_id = get_backup_id()
         if current_backup_id and current_backup_id == backup_id:
             LOGGER.warning(
-                "Canceling backup with ID %s. %s",
+                "Canceling backup with ID %s: %s",
                 backup_id,
                 reason,
             )
@@ -330,33 +328,170 @@ def cancel_backup(backup_id, reason):
         pass
 
 
-def journal_utilization():
-    if JOURNAL_DIR is not None:
-        total, used, _ = disk_usage(JOURNAL_DIR)
-        return (used / total) * 100
+class CancelationPolicy:
+    _lock = Lock()
+    _rules = None
+
+    @classmethod
+    def load(cls, policy_config):
+        rules = cls.parse(policy_config)
+        if not rules and JOURNAL_DIR is not None:
+            # add default cancelation rules
+            rules.append(JournalUtilizationRule.from_dict(op=">", threshold=80))
+        with cls._lock:
+            cls._rules = rules
+
+    @classmethod
+    def rules(cls):
+        with cls._lock:
+            if cls._rules is not None:
+                return [copy.deepcopy(r) for r in cls._rules]
+            return []
+
+    @classmethod
+    def apply(cls, backup_id, interval=CANCELATION_POLICY_INTERVAL):
+        rules = cls.rules()
+
+        def monitor():
+            while get_backup_id() == backup_id:
+                errors = []
+                for rule in rules:
+                    err_msg = rule.evaluate()
+                    if err_msg:
+                        errors.append(err_msg)
+                if len(errors) > 0:
+                    # some of the rules are satisfied so cancel the backup operation
+                    cancel_backup(backup_id, "; ".join(errors))
+                    break
+                time.sleep(interval)
+            LOGGER.debug("Stopped monitoring backup %s", backup_id)
+
+        if len(rules) > 0:
+            Thread(target=monitor, daemon=True).start()
+
+    @staticmethod
+    def parse(policy_config):
+        if not policy_config:
+            return []
+        if not os.path.exists(policy_config):
+            LOGGER.info(
+                "Ignoring non-existent cancelation policy config %s", policy_config
+            )
+            return []
+        try:
+            rules = []
+            with open(policy_config) as f:
+                config_data = json.loads(f.read())
+                rules_list = config_data.get("rules")
+                if rules_list:
+                    for rule in rules_list:
+                        rule_type = rule.get("type")
+                        if rule_type == "script":
+                            rules.append(ScriptCancelationRule.from_dict(**rule))
+                        elif (
+                            rule_type == "journalUtilization"
+                            and JOURNAL_DIR is not None
+                        ):
+                            rules.append(JournalUtilizationRule.from_dict(**rule))
+                        else:
+                            LOGGER.info(
+                                "Ignoring unknown policy rule type=%s", rule_type
+                            )
+            return rules
+        except Exception:
+            LOGGER.exception(
+                "Unable to process cancelation policy config %s", policy_config
+            )
+            return []
 
 
-def monitor_journal_size(backup_id, threshold, interval=5, duration=30):
-    alert_time = None
-    while get_backup_id() == backup_id:
-        now = time.monotonic()
-        util = journal_utilization()
-        LOGGER.debug("Journal volume utilization %.2f", util)
-        # check if utilization is above threshold
-        if util > threshold:
-            if alert_time is None:
-                alert_time = now
-            elif now - alert_time >= duration:
-                # elapsed time more than the specified duration so cancel the
-                # backup operation
-                cancel_backup(
-                    backup_id,
-                    f"Journal volume utilization {util:.2f}% above threshold ({threshold}%)",
-                )
-        else:
-            # reset the time once utilization drops below threshold
-            alert_time = None
-        time.sleep(interval)
+OPS = {
+    ">": (operator.gt, "greater than"),
+    "<": (operator.lt, "less than"),
+    ">=": (operator.ge, "greater than or equal to"),
+    "<=": (operator.le, "less than or equal to"),
+    "==": (operator.eq, "equal to"),
+    "!=": (operator.ne, "not equal to"),
+}
+
+
+class CancelationRule:
+
+    MSG_FMT = "{rule.name} value {value:.2f} is {rule.op} {rule.threshold} for more than {rule.duration}s"  # pylint: disable=line-too-long
+
+    def __init__(
+        self, name, op, threshold, duration=60, **kwargs
+    ):  # pylint: disable=unused-argument
+        self.name = name
+        self.check = OPS[op][0]
+        self.op = OPS[op][1]
+        self.threshold = threshold
+        self.duration = duration
+        self._alert_time = None
+
+    def apply(self, **kwargs):
+        raise NotImplementedError()
+
+    def evaluate(self, **kwargs):
+        try:
+            now = time.monotonic()
+            value = self.apply(**kwargs)
+            LOGGER.debug("%s current value: %.2f", self.name, value)
+            # check if current value satisfies the threshold
+            if self.check(value, self.threshold):
+                if self._alert_time is None:
+                    self._alert_time = now
+                elif now - self._alert_time >= self.duration:
+                    return self.MSG_FMT.format(value=value, rule=self)
+            else:
+                # reset the time
+                self._alert_time = None
+        except Exception as e:
+            LOGGER.warning(
+                "Failed to evaluate cancelation rule name='%s': %s", self.name, str(e)
+            )
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        name = kwargs.pop("name")
+        op = kwargs.pop("op")
+        threshold = kwargs.pop("threshold")
+        return cls(name, op, threshold, **kwargs)
+
+
+class JournalUtilizationRule(CancelationRule):
+
+    def apply(self, **kwargs):
+        if JOURNAL_DIR is not None:
+            total, used, _ = disk_usage(JOURNAL_DIR)
+            return (used / total) * 100
+        return 0
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        op = kwargs.pop("op")
+        threshold = kwargs.pop("threshold")
+        return cls("Journal volume utilization percentage", op, threshold, **kwargs)
+
+
+class ScriptCancelationRule(CancelationRule):
+
+    def __init__(
+        self, name, op, threshold, script, duration=None, timeout=60, **kwargs
+    ):  # pylint: disable=unused-argument
+        super().__init__(name, op, threshold, duration)
+        self.script = script
+        self.timeout = timeout
+
+    def apply(self, **kwargs):
+        out = subprocess.check_output(
+            self.script,
+            shell=True,
+            stderr=subprocess.STDOUT,
+            env=dict(os.environ),
+            timeout=self.timeout,
+        )
+        return float(out.decode("utf-8"))
 
 
 def schedule_cancellation(backup_id, timeout=None):
@@ -365,14 +500,8 @@ def schedule_cancellation(backup_id, timeout=None):
         Timer(
             timeout, lambda: cancel_backup(backup_id, f"Timeout after {timeout}s.")
         ).start()
-    if JOURNAL_DIR is not None:
-        # schedule cancelation based on journal size
-        Thread(
-            target=monitor_journal_size,
-            args=(backup_id, MAX_JOURNAL_PERCENT_THRESHOLD),
-            kwargs={"interval": MAX_JOURNAL_INTERVAL, "duration": MAX_JOURNAL_DURATION},
-            daemon=True,
-        ).start()
+    # schedule cancelation based on configured policy
+    CancelationPolicy.apply(backup_id)
 
 
 def post_backup(backup_id, query):
@@ -841,6 +970,7 @@ def verify_prerequisites():
 def main():
     # Create CLI parser for direct invocation
     parser = argparse.ArgumentParser(sys.argv[0])
+    parser.add_argument("--cancel-policy", default="/etc/nuodb/cancel-policy.json")
     subparsers = parser.add_subparsers(dest="subcommand")
     # Register server subcommand
     subparser = subparsers.add_parser("server")
@@ -860,6 +990,8 @@ def main():
     args = parser.parse_args(sys.argv[1:])
     if args.subcommand:
         verify_prerequisites()
+    # Load backup cancelation policy
+    CancelationPolicy.load(args.cancel_policy)
     if args.subcommand == "server":
         start_server(args.port, args.handler_config)
     if args.subcommand == "pre-hook":

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -10,7 +10,7 @@ import sys
 import time
 import urllib
 import wsgiref.util
-from threading import Lock, Timer
+from threading import Lock, Timer, Thread
 from shutil import which, disk_usage
 
 import werkzeug
@@ -26,6 +26,12 @@ ARCHIVE_DIR = os.environ.get("NUODB_ARCHIVE_DIR", "/mnt/archive")
 JOURNAL_DIR = os.environ.get("NUODB_JOURNAL_DIR")
 FREEZE_MODE = os.environ.get("FREEZE_MODE")
 FREEZE_TIMEOUT = os.environ.get("FREEZE_TIMEOUT")
+
+MAX_JOURNAL_PERCENT_THRESHOLD = float(
+    os.environ.get("MAX_JOURNAL_PERCENT_THRESHOLD", 80)
+)
+MAX_JOURNAL_DURATION = int(os.environ.get("MAX_JOURNAL_DURATION", 30))
+MAX_JOURNAL_INTERVAL = int(os.environ.get("MAX_JOURNAL_INTERVAL", 5))
 
 MODE_HOTSNAP = "hotsnap"
 MODE_FSFREEZE = "fsfreeze"
@@ -305,28 +311,68 @@ def pre_backup(backup_id, payload):
         if JOURNAL_DIR is not None:
             freeze_archive(backup_id, processes, timeout=timeout)
 
-        # Cancel backup operation after specified timeout
+        # Cancel backup operation prematurely
         schedule_cancellation(backup_id, timeout)
 
 
-def schedule_cancellation(backup_id, timeout):
+def cancel_backup(backup_id, reason):
+    try:
+        current_backup_id = get_backup_id()
+        if current_backup_id and current_backup_id == backup_id:
+            LOGGER.warning(
+                "Canceling backup with ID %s. %s",
+                backup_id,
+                reason,
+            )
+            post_backup(backup_id, query={})
+    except ArchivingNotPausedError:
+        # Suppress this error during backup cancellation
+        pass
+
+
+def journal_utilization():
+    if JOURNAL_DIR is not None:
+        total, used, _ = disk_usage(JOURNAL_DIR)
+        return (used / total) * 100
+
+
+def monitor_journal_size(backup_id, threshold, interval=5, duration=30):
+    alert_time = None
+    while get_backup_id() == backup_id:
+        now = time.monotonic()
+        util = journal_utilization()
+        LOGGER.debug("Journal volume utilization %.2f", util)
+        # check if utilization is above threshold
+        if util > threshold:
+            if alert_time is None:
+                alert_time = now
+            elif now - alert_time >= duration:
+                # elapsed time more than the specified duration so cancel the
+                # backup operation
+                cancel_backup(
+                    backup_id,
+                    f"Journal volume utilization {util:.2f}% above threshold ({threshold}%)",
+                )
+        else:
+            # reset the time once utilization drops below threshold
+            alert_time = None
+        time.sleep(interval)
+
+
+def schedule_cancellation(backup_id, timeout=None):
     if timeout and timeout > 0:
-
-        def cancel_backup():
-            try:
-                current_backup_id = get_backup_id()
-                if current_backup_id and current_backup_id == backup_id:
-                    LOGGER.warning(
-                        "Canceling backup with ID %s. Timeout after %ds.",
-                        backup_id,
-                        timeout,
-                    )
-                    post_backup(backup_id, query={})
-            except ArchivingNotPausedError:
-                # Suppress this error during backup cancellation
-                pass
-
-        Timer(timeout, cancel_backup).start()
+        # schedule cancelation based on timeout
+        Timer(
+            timeout, lambda: cancel_backup(backup_id, f"Timeout after {timeout}s.")
+        ).start()
+    if JOURNAL_DIR is not None:
+        # schedule cancelation based on journal size
+        Thread(
+            target=monitor_journal_size,
+            args=(backup_id, MAX_JOURNAL_PERCENT_THRESHOLD),
+            kwargs={"interval": MAX_JOURNAL_INTERVAL, "duration": MAX_JOURNAL_DURATION},
+            daemon=True,
+        ).start()
 
 
 def post_backup(backup_id, query):

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -791,7 +791,8 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
 
                 # verify monitoring thread has exited
                 assert any(
-                    f"Stopped monitoring backup {backup_id}" in record.message
+                    f"Stopped cancelation policy for backup {backup_id}"
+                    in record.message
                     for record in logs.records
                 ), logs.output
 

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -98,6 +98,9 @@ class HttpHandlersTests(unittest.TestCase):
             self.logs_dir = os.path.join(self.test_dir, "cores")
             os.makedirs(self.logs_dir)
             os.environ["NUODB_LOGDIR"] = self.logs_dir
+        for k, v in server_config.items():
+            if k.startswith("env_"):
+                os.environ[k[4:]] = v
         # Configure custom handlers
         handler_config = None
         custom_handlers = server_config.get("custom_handlers")
@@ -566,6 +569,57 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
     def tearDown(self):
         super().tearDown()
         self.freeze_archive_patch.stop()
+
+    @ConfigOverrides(env_MAX_JOURNAL_DURATION="5", env_MAX_JOURNAL_INTERVAL="1")
+    @mock.patch("backup_hooks.journal_utilization")
+    def testBackupCancelationOnJournalUtilization(self, journal_usage_mock=None):
+        # set journal utilization below threshold (80%)
+        journal_usage_mock.return_value = 50
+
+        # invoke pre-backup hook
+        backup_id = str(uuid.uuid4())
+        resp, data = self.pre_backup(backup_id)
+        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+        self.assertTrue(data["success"], "pre-backup hook reported failure")
+
+        # verify that backup.txt file is created
+        self.assertFileContent(os.path.join(self.archive_dir, "backup.txt"), backup_id)
+
+        # verify that archive has been freezed
+        self.freeze_archive_mock.assert_called_once_with(
+            backup_id, self.nuodb_processes_mock.return_value, timeout=None
+        )
+        self.freeze_archive_mock.reset_mock()
+
+        def assert_archiving_resumed():
+            self.freeze_archive_mock.assert_called_once_with(
+                backup_id, self.nuodb_processes_mock.return_value, unfreeze=True
+            )
+            self.assertFileNotExist(os.path.join(self.archive_dir, "backup.txt"))
+
+        # increase journal utilization to 95%
+        journal_usage_mock.return_value = 95
+
+        # wait two seconds and verify that the archiving is still paused and
+        # backup.txt file is not deleted
+        time.sleep(2)
+        self.freeze_archive_mock.assert_not_called()
+        self.assertFileContent(os.path.join(self.archive_dir, "backup.txt"), backup_id)
+
+        # decrease journal utilization to 70%
+        journal_usage_mock.return_value = 70
+
+        # wait another two seconds and verify that the archiving is still paused
+        # and backup.txt file is not deleted
+        time.sleep(2)
+        self.freeze_archive_mock.assert_not_called()
+        self.assertFileContent(os.path.join(self.archive_dir, "backup.txt"), backup_id)
+
+        # increase journal utilization again above threshold
+        journal_usage_mock.return_value = 85
+
+        # wait for backup operation to be canceled
+        retry(lambda: assert_archiving_resumed, 10)
 
 
 class NoArchivesHandlersTest(HttpHandlersTests):

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -98,9 +98,7 @@ class HttpHandlersTests(unittest.TestCase):
             self.logs_dir = os.path.join(self.test_dir, "cores")
             os.makedirs(self.logs_dir)
             os.environ["NUODB_LOGDIR"] = self.logs_dir
-        for k, v in server_config.items():
-            if k.startswith("env_"):
-                os.environ[k[4:]] = v
+        os.environ.update(server_config.get("env", {}))
         # Configure custom handlers
         handler_config = None
         custom_handlers = server_config.get("custom_handlers")
@@ -157,6 +155,14 @@ class HttpHandlersTests(unittest.TestCase):
 
     def start_server(self, handler_config=None):
         handler_config = self.configure_server()
+        # configure cancelation policy
+        cancel_rules = self.get_server_config().get("cancel_rules")
+        if cancel_rules:
+            policy_config = os.path.join(self.test_dir, "cancel-policy.json")
+            with open(policy_config, "w") as f:
+                f.write(json.dumps(dict(rules=cancel_rules)))
+            backup_hooks.CancelationPolicy.load(policy_config)
+        # start HTTP server
         self.host = "127.0.0.1"
         self.port = self.get_local_port()
         LOGGER.info("Starting hooks server on %s:%d", self.host, self.port)
@@ -570,56 +576,226 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
         super().tearDown()
         self.freeze_archive_patch.stop()
 
-    @ConfigOverrides(env_MAX_JOURNAL_DURATION="5", env_MAX_JOURNAL_INTERVAL="1")
-    @mock.patch("backup_hooks.journal_utilization")
-    def testBackupCancelationOnJournalUtilization(self, journal_usage_mock=None):
-        # set journal utilization below threshold (80%)
-        journal_usage_mock.return_value = 50
+    def _testBackupCancelation(self, set_good, set_bad, log_msg):
+        with self.assertLogs(logger=LOGGER, level="DEBUG") as logs:
+            # set value that does not satisfy the rule
+            set_good()
 
-        # invoke pre-backup hook
-        backup_id = str(uuid.uuid4())
-        resp, data = self.pre_backup(backup_id)
-        self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
-        self.assertTrue(data["success"], "pre-backup hook reported failure")
+            # invoke pre-backup hook
+            backup_id = str(uuid.uuid4())
+            resp, data = self.pre_backup(backup_id)
+            self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+            self.assertTrue(data["success"], "pre-backup hook reported failure")
 
-        # verify that backup.txt file is created
-        self.assertFileContent(os.path.join(self.archive_dir, "backup.txt"), backup_id)
+            # verify that backup.txt file is created
+            self.assertFileContent(
+                os.path.join(self.archive_dir, "backup.txt"), backup_id
+            )
 
-        # verify that archive has been freezed
-        self.freeze_archive_mock.assert_called_once_with(
-            backup_id, self.nuodb_processes_mock.return_value, timeout=None
+            # verify that archive has been freezed
+            self.freeze_archive_mock.assert_called_once_with(
+                backup_id, self.nuodb_processes_mock.return_value, timeout=None
+            )
+            self.freeze_archive_mock.reset_mock()
+
+            def assert_archiving_resumed():
+                # verify that archiving has been resumed
+                self.freeze_archive_mock.assert_called_once_with(
+                    backup_id, self.nuodb_processes_mock.return_value, unfreeze=True
+                )
+
+                # verify that backup.txt is removed
+                self.assertFileNotExist(os.path.join(self.archive_dir, "backup.txt"))
+
+                # verify cancelation log message
+                assert any(
+                    f"Canceling backup with ID {backup_id}: {log_msg}" in record.message
+                    for record in logs.records
+                ), logs.output
+
+                # verify monitoring thread has exited
+                assert any(
+                    f"Stopped monitoring backup {backup_id}" in record.message
+                    for record in logs.records
+                ), logs.output
+
+            # set value that satisfies the rules
+            set_bad()
+
+            # wait two seconds and verify that the archiving is still paused and
+            # backup.txt file is not deleted
+            time.sleep(2)
+            self.freeze_archive_mock.assert_not_called()
+            self.assertFileContent(
+                os.path.join(self.archive_dir, "backup.txt"), backup_id
+            )
+
+            # set value that does not satisfy the rule
+            set_good()
+
+            # wait another two seconds and verify that the archiving is still paused
+            # and backup.txt file is not deleted
+            time.sleep(2)
+            self.freeze_archive_mock.assert_not_called()
+            self.assertFileContent(
+                os.path.join(self.archive_dir, "backup.txt"), backup_id
+            )
+
+            # set value that satisfies the rule again
+            set_bad()
+
+            # wait for backup operation to be canceled
+            retry(assert_archiving_resumed, 10)
+
+    @ConfigOverrides(
+        env={"CANCELATION_POLICY_INTERVAL": "1"},
+        cancel_rules=[
+            {
+                "type": "journalUtilization",
+                "op": ">",
+                "threshold": 80,
+                "duration": 5,
+            }
+        ],
+    )
+    @mock.patch("backup_hooks.JournalUtilizationRule.apply")
+    def testBackupCancelationOnJournalUtilization(self, journal_util_mock=None):
+        def set_good():
+            journal_util_mock.return_value = 50
+
+        def set_bad():
+            journal_util_mock.return_value = 85
+
+        self._testBackupCancelation(
+            set_good,
+            set_bad,
+            "Journal volume utilization percentage value 85.00 is greater than 80 for more than 5s",
         )
-        self.freeze_archive_mock.reset_mock()
 
-        def assert_archiving_resumed():
+    @ConfigOverrides(
+        env={"CANCELATION_POLICY_INTERVAL": "1"},
+        cancel_rules=[
+            {
+                "type": "script",
+                "name": "Memory throttling",
+                "script": "cat /tmp/memory_throttling",
+                "op": ">",
+                "threshold": 0,
+                "duration": 5,
+            }
+        ],
+    )
+    @mock.patch("backup_hooks.JournalUtilizationRule.apply")
+    def testBackupCancelationOnScriptRule(self, journal_util_mock=None):
+        journal_util_mock.return_value = 50
+        memory_throttling = Path("/tmp/memory_throttling")
+
+        def set_good():
+            memory_throttling.write_text("0")
+
+        def set_bad():
+            memory_throttling.write_text("32")
+
+        self._testBackupCancelation(
+            set_good,
+            set_bad,
+            "Memory throttling value 32.00 is greater than 0 for more than 5s",
+        )
+
+    @ConfigOverrides(
+        env={"CANCELATION_POLICY_INTERVAL": "1"},
+        cancel_rules=[
+            {
+                "type": "journalUtilization",
+                "op": ">",
+                "threshold": 80,
+                "duration": 5,
+            },
+            {
+                "type": "script",
+                "name": "Memory throttling",
+                "script": "cat /tmp/memory_throttling",
+                "op": ">",
+                "threshold": 0,
+                "duration": 5,
+            },
+        ],
+    )
+    @mock.patch("backup_hooks.JournalUtilizationRule.apply")
+    def testBackupCancelationOnMultipleRules(self, journal_util_mock=None):
+        memory_throttling = Path("/tmp/memory_throttling")
+
+        def set_good():
+            journal_util_mock.return_value = 50
+            memory_throttling.write_text("0")
+
+        def set_bad():
+            journal_util_mock.return_value = 95
+            memory_throttling.write_text("32")
+
+        self._testBackupCancelation(
+            set_good,
+            set_bad,
+            "Journal volume utilization percentage value 95.00 is greater than 80 for more than 5s; "
+            + "Memory throttling value 32.00 is greater than 0 for more than 5s",
+        )
+
+    @ConfigOverrides(
+        env={"CANCELATION_POLICY_INTERVAL": "1"},
+    )
+    @mock.patch("backup_hooks.JournalUtilizationRule.apply")
+    def testBackupNotCanceled(self, journal_util_mock=None):
+        journal_util_mock.return_value = 50
+
+        with self.assertLogs(logger=LOGGER, level="DEBUG") as logs:
+            # invoke pre-backup hook
+            backup_id = str(uuid.uuid4())
+            resp, data = self.pre_backup(backup_id)
+            self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+            self.assertTrue(data["success"], "pre-backup hook reported failure")
+
+            # verify that archive has been freezed
+            self.freeze_archive_mock.assert_called_once_with(
+                backup_id, self.nuodb_processes_mock.return_value, timeout=None
+            )
+            self.freeze_archive_mock.reset_mock()
+
+            # set utilization above threshold
+            journal_util_mock.return_value = 95
+
+            # wait two seconds and verify that the archiving is still paused and
+            # backup.txt file is not deleted
+            time.sleep(2)
+            self.freeze_archive_mock.assert_not_called()
+            self.assertFileContent(
+                os.path.join(self.archive_dir, "backup.txt"), backup_id
+            )
+            self.freeze_archive_mock.reset_mock()
+
+            # invoke post-backup hook
+            resp, data = self.post_backup(backup_id)
+            self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+            self.assertTrue(data["success"], "post-backup hook reported failure")
+
+            # verify that archive has been unfreezed
             self.freeze_archive_mock.assert_called_once_with(
                 backup_id, self.nuodb_processes_mock.return_value, unfreeze=True
             )
-            self.assertFileNotExist(os.path.join(self.archive_dir, "backup.txt"))
 
-        # increase journal utilization to 95%
-        journal_usage_mock.return_value = 95
+            def assert_logs():
+                # verify that backup operation hasn't been canceled
+                assert not any(
+                    f"Canceling backup with ID {backup_id}" in record.message
+                    for record in logs.records
+                ), logs.output
 
-        # wait two seconds and verify that the archiving is still paused and
-        # backup.txt file is not deleted
-        time.sleep(2)
-        self.freeze_archive_mock.assert_not_called()
-        self.assertFileContent(os.path.join(self.archive_dir, "backup.txt"), backup_id)
+                # verify monitoring thread has exited
+                assert any(
+                    f"Stopped monitoring backup {backup_id}" in record.message
+                    for record in logs.records
+                ), logs.output
 
-        # decrease journal utilization to 70%
-        journal_usage_mock.return_value = 70
-
-        # wait another two seconds and verify that the archiving is still paused
-        # and backup.txt file is not deleted
-        time.sleep(2)
-        self.freeze_archive_mock.assert_not_called()
-        self.assertFileContent(os.path.join(self.archive_dir, "backup.txt"), backup_id)
-
-        # increase journal utilization again above threshold
-        journal_usage_mock.return_value = 85
-
-        # wait for backup operation to be canceled
-        retry(lambda: assert_archiving_resumed, 10)
+            retry(assert_logs, 10)
 
 
 class NoArchivesHandlersTest(HttpHandlersTests):

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -18,6 +18,7 @@ from threading import Thread
 from werkzeug.serving import make_server
 import sys
 import shlex
+import tempfile
 
 import metrics
 import backup_hooks
@@ -80,8 +81,7 @@ class HttpHandlersTests(unittest.TestCase):
         config = getattr(self, "server_config", {})
         testMethod = getattr(self, self._testMethodName)
         overrides = getattr(testMethod, "overrides", {})
-        config.update(overrides)
-        return config
+        return {**config, **overrides}
 
     def configure_server(self):
         server_config = self.get_server_config()
@@ -157,11 +157,12 @@ class HttpHandlersTests(unittest.TestCase):
         handler_config = self.configure_server()
         # configure cancelation policy
         cancel_rules = self.get_server_config().get("cancel_rules")
+        policy_config = os.path.join(self.test_dir, "cancel-policy.json")
         if cancel_rules:
-            policy_config = os.path.join(self.test_dir, "cancel-policy.json")
             with open(policy_config, "w") as f:
                 f.write(json.dumps(dict(rules=cancel_rules)))
-            backup_hooks.CancelationPolicy.load(policy_config)
+        # load the cancelation policy unconditionally as in main()
+        backup_hooks.CancelationPolicy.load(policy_config)
         # start HTTP server
         self.host = "127.0.0.1"
         self.port = self.get_local_port()
@@ -432,11 +433,11 @@ class BackupHooksTest(HttpHandlersTests):
         self.nuodb_processes_patch.stop()
         super().tearDown()
 
-    def pre_backup(self, backup_id, opaque=None):
+    def pre_backup(self, backup_id, opaque=None, timeout=None):
         resp, data = self.request(
             method="POST",
             path=f"/pre-backup/{backup_id}",
-            body=json.dumps(dict(opaque=opaque)),
+            body=json.dumps(dict(opaque=opaque, timeout=timeout)),
             headers={"Content-Type": "application/json"},
         )
         return resp, json.loads(data)
@@ -583,7 +584,7 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
 
             # invoke pre-backup hook
             backup_id = str(uuid.uuid4())
-            resp, data = self.pre_backup(backup_id)
+            resp, data = self.pre_backup(backup_id, timeout=60)
             self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
             self.assertTrue(data["success"], "pre-backup hook reported failure")
 
@@ -594,7 +595,7 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
 
             # verify that archive has been freezed
             self.freeze_archive_mock.assert_called_once_with(
-                backup_id, self.nuodb_processes_mock.return_value, timeout=None
+                backup_id, self.nuodb_processes_mock.return_value, timeout=60
             )
             self.freeze_archive_mock.reset_mock()
 
@@ -616,6 +617,13 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
                 # verify monitoring thread has exited
                 assert any(
                     f"Stopped monitoring backup {backup_id}" in record.message
+                    for record in logs.records
+                ), logs.output
+
+                # verify that policy threads have been stopped
+                assert any(
+                    f"Stopped cancelation policy for backup {backup_id}"
+                    in record.message
                     for record in logs.records
                 ), logs.output
 
@@ -750,13 +758,13 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
         with self.assertLogs(logger=LOGGER, level="DEBUG") as logs:
             # invoke pre-backup hook
             backup_id = str(uuid.uuid4())
-            resp, data = self.pre_backup(backup_id)
+            resp, data = self.pre_backup(backup_id, timeout=10)
             self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
             self.assertTrue(data["success"], "pre-backup hook reported failure")
 
             # verify that archive has been freezed
             self.freeze_archive_mock.assert_called_once_with(
-                backup_id, self.nuodb_processes_mock.return_value, timeout=None
+                backup_id, self.nuodb_processes_mock.return_value, timeout=10
             )
             self.freeze_archive_mock.reset_mock()
 
@@ -783,13 +791,7 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
             )
 
             def assert_logs():
-                # verify that backup operation hasn't been canceled
-                assert not any(
-                    f"Canceling backup with ID {backup_id}" in record.message
-                    for record in logs.records
-                ), logs.output
-
-                # verify monitoring thread has exited
+                # verify monitoring threads have exited
                 assert any(
                     f"Stopped cancelation policy for backup {backup_id}"
                     in record.message
@@ -797,6 +799,83 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
                 ), logs.output
 
             retry(assert_logs, 10)
+
+            # verify that backup operation hasn't been canceled
+            assert not any(
+                f"Canceling backup with ID {backup_id}" in record.message
+                for record in logs.records
+            ), logs.output
+
+    def testBackupCancelationPolicyNegative(self):
+        def parse_rules(rules_config):
+            with tempfile.NamedTemporaryFile(dir=self.test_dir, delete=False) as tmp:
+                tmp.write(json.dumps(dict(rules=rules_config)).encode("utf-8"))
+                tmp.close()
+                return backup_hooks.CancelationPolicy.parse(tmp.name)
+
+        # verify that rule with missing type is ignored
+        with self.assertLogs(logger=LOGGER) as logs:
+            rules_config = [
+                {
+                    "op": ">",
+                    "threshold": 80,
+                    "duration": 5,
+                }
+            ]
+            rules = parse_rules(rules_config)
+            assert not rules
+            assert any(
+                f"Ignoring invalid policy rule {rules_config[0]}" in record.message
+                for record in logs.records
+            ), logs.output
+
+        # verify that rule with invalid operation is ignored
+        with self.assertLogs(logger=LOGGER) as logs:
+            rules_config = [
+                {
+                    "type": "script",
+                    "script": "echo '0'",
+                    "op": "bogus",
+                    "threshold": 80,
+                    "duration": 5,
+                }
+            ]
+            rules = parse_rules(rules_config)
+            assert not rules
+            assert any(
+                f"Ignoring invalid policy rule {rules_config[0]}" in record.message
+                for record in logs.records
+            ), logs.output
+
+        # verify that rule with missing threshold is ignored
+        with self.assertLogs(logger=LOGGER) as logs:
+            rules_config = [
+                {
+                    "type": "script",
+                    "script": "echo '0'",
+                    "op": "!=",
+                }
+            ]
+            rules = parse_rules(rules_config)
+            assert not rules
+            assert any(
+                f"Ignoring invalid policy rule {rules_config[0]}" in record.message
+                for record in logs.records
+            ), logs.output
+
+        # verify that valid rules are returned
+        with self.assertLogs(logger=LOGGER) as logs:
+            rules_config = [
+                {"type": "script", "script": "echo '0'", "op": "bogus", "threshold": 0},
+                {"type": "journalUtilization", "op": ">", "threshold": 80},
+            ]
+            rules = parse_rules(rules_config)
+            assert len(rules) == 1
+            assert rules[0].RULE_TYPE == "journalUtilization"
+            assert any(
+                f"Ignoring invalid policy rule {rules_config[0]}" in record.message
+                for record in logs.records
+            ), logs.output
 
 
 class NoArchivesHandlersTest(HttpHandlersTests):


### PR DESCRIPTION
**Changes**

This change adds support for backup cancellation policy with configurable
rules. By default, the policy will cancel the ongoing backup operation if the
journal directory utilization increases above 80%. Additional script
cancellation rules can be configured by the user to allow custom behaviour.

**Testing**

- unit tests 