### PR TITLE
Add support for HEAD requests and list cores as a map

### DIFF
--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -593,6 +593,8 @@ def read_handler_config(handler_config):
 class RequestInfo(object):  # pylint: disable=too-few-public-methods
     def __init__(self, environ):
         self.method = environ.get("REQUEST_METHOD")
+        if self.method == "HEAD":
+            self.method = "GET"
         # Parse URL and make sure it contains at least one path component
         uri = wsgiref.util.request_uri(environ)
         self.parsed = urllib.parse.urlparse(uri)

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -593,8 +593,6 @@ def read_handler_config(handler_config):
 class RequestInfo(object):  # pylint: disable=too-few-public-methods
     def __init__(self, environ):
         self.method = environ.get("REQUEST_METHOD")
-        if self.method == "HEAD":
-            self.method = "GET"
         # Parse URL and make sure it contains at least one path component
         uri = wsgiref.util.request_uri(environ)
         self.parsed = urllib.parse.urlparse(uri)

--- a/nuodb-operations/cores.py
+++ b/nuodb-operations/cores.py
@@ -23,7 +23,7 @@ def cores_handlers() -> list[tuple[str, str, callable]]:
     ]
 
 
-def list_cores(query: dict[str:Any]) -> list[tuple[str, int, str]]:
+def list_cores(query: dict[str:Any]) -> list[dict[str, Any]]:
     """List available cores
 
     query parameters:
@@ -49,10 +49,10 @@ def list_cores(query: dict[str:Any]) -> list[tuple[str, int, str]]:
         if after >= 0 and after >= timestamp:
             continue
         with open(core, "rb") as f:
-            filehash = hashlib.file_digest(f, hashlib.sha1).hexdigest()
-        entry = (name, int(timestamp), filehash)
+            checksum = hashlib.file_digest(f, hashlib.sha1).hexdigest()
+        entry = {"name": name, "timestamp": int(timestamp), "checksum": checksum}
         cores.append(entry)
-    cores.sort(key=itemgetter(0))
+    cores.sort(key=itemgetter("name"))
     return cores
 
 

--- a/nuodb-operations/cores.py
+++ b/nuodb-operations/cores.py
@@ -19,6 +19,7 @@ def cores_handlers() -> list[tuple[str, str, callable]]:
     """Get /cores handlers"""
     return [
         ("GET", "cores", [list_cores, get_core]),
+        ("HEAD", "cores", [get_core]),
         ("DELETE", "cores", [delete_core]),
     ]
 

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -803,9 +803,14 @@ class CoresHandlersTest(HttpHandlersTests):
         self.assertLessEqual(core["timestamp"], ts_after)
         self.assertEqual(core["checksum"], hashlib.sha1(file_contents).hexdigest())
 
-        resp, _ = self.get_core(core_name, method="HEAD")
+        resp, data = self.get_core(core_name, method="HEAD")
         self.assertEqual(resp.status, http.HTTPStatus.OK)
-        self.assertEqual(int(resp.getheader("Content-Length")), len(file_contents), "Wrong Content-Length in HEAD response")
+        self.assertEqual(
+            int(resp.getheader("Content-Length")),
+            len(file_contents),
+            "Wrong Content-Length in HEAD response",
+        )
+        self.assertEqual(data, b"", "HEAD response should be empty")
 
         pagesize = 100
         for page_start in range(0, len(file_contents), pagesize):

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -618,12 +618,12 @@ class CoresHandlersTest(HttpHandlersTests):
         resp, data = self.request(method="GET", path=path)
         return resp, json.loads(data)
 
-    def get_core(self, core_path, range_start="", range_end=""):
+    def get_core(self, core_path, method="GET", range_start="", range_end=""):
         headers = {}
         if range_start or range_end:
             headers["Range"] = f"bytes={range_start}-{range_end}"
         resp, data = self.request(
-            method="GET", path=f"/cores/{core_path}", headers=headers
+            method=method, path=f"/cores/{core_path}", headers=headers
         )
         return resp, data
 
@@ -674,11 +674,11 @@ class CoresHandlersTest(HttpHandlersTests):
         resp, cores = self.get_cores()
         self.assertEqual(resp.status, http.HTTPStatus.OK)
         self.assertEqual(len(cores), 1)
-        name, timestamp, filehash = cores[0]
-        self.assertEqual(name, core_name)
-        self.assertGreaterEqual(timestamp, ts_before)
-        self.assertLessEqual(timestamp, ts_after)
-        self.assertEqual(filehash, hashlib.sha1(file_contents).hexdigest())
+        core = cores[0]
+        self.assertEqual(core["name"], core_name)
+        self.assertGreaterEqual(core["timestamp"], ts_before)
+        self.assertLessEqual(core["timestamp"], ts_after)
+        self.assertEqual(core["checksum"], hashlib.sha1(file_contents).hexdigest())
 
         resp, core = self.get_core(core_name)
         self.assertEqual(resp.status, http.HTTPStatus.OK)
@@ -744,20 +744,19 @@ class CoresHandlersTest(HttpHandlersTests):
         self.assertEqual(resp.status, http.HTTPStatus.OK, cores)
         self.assertEqual(len(cores), len(expected_cores))
         for i, core in enumerate(cores):
-            name, timestamp, filehash = core
-            self.assertEqual(name, expected_cores[i])
-            self.assertGreaterEqual(timestamp, ts_before)
-            self.assertLessEqual(timestamp, ts_after)
-            self.assertEqual(filehash, expected_hash)
+            self.assertEqual(core["name"], expected_cores[i])
+            self.assertGreaterEqual(core["timestamp"], ts_before)
+            self.assertLessEqual(core["timestamp"], ts_after)
+            self.assertEqual(core["checksum"], expected_hash)
 
         resp, cores = self.get_cores(after=last_core_time)
         self.assertEqual(resp.status, http.HTTPStatus.OK, cores)
         self.assertEqual(len(cores), 1)
-        name, timestamp, filehash = cores[0]
-        self.assertEqual(name, "789T123-core.nuodb.abc.210")
-        self.assertGreaterEqual(timestamp, last_core_time)
-        self.assertLessEqual(timestamp, ts_after)
-        self.assertEqual(filehash, expected_hash)
+        core = cores[0]
+        self.assertEqual(core["name"], "789T123-core.nuodb.abc.210")
+        self.assertGreaterEqual(core["timestamp"], last_core_time)
+        self.assertLessEqual(core["timestamp"], ts_after)
+        self.assertEqual(core["checksum"], expected_hash)
 
         # Test that get and delete also ignore the non-core files
         resp, data = self.get_core("nuosm.log")
@@ -798,11 +797,15 @@ class CoresHandlersTest(HttpHandlersTests):
         resp, cores = self.get_cores()
         self.assertEqual(resp.status, http.HTTPStatus.OK)
         self.assertEqual(len(cores), 1)
-        name, timestamp, filehash = cores[0]
-        self.assertEqual(name, core_name)
-        self.assertGreaterEqual(timestamp, ts_before)
-        self.assertLessEqual(timestamp, ts_after)
-        self.assertEqual(filehash, hashlib.sha1(file_contents).hexdigest())
+        core = cores[0]
+        self.assertEqual(core["name"], core_name)
+        self.assertGreaterEqual(core["timestamp"], ts_before)
+        self.assertLessEqual(core["timestamp"], ts_after)
+        self.assertEqual(core["checksum"], hashlib.sha1(file_contents).hexdigest())
+
+        resp, _ = self.get_core(core_name, method="HEAD")
+        self.assertEqual(resp.status, http.HTTPStatus.OK)
+        self.assertEqual(int(resp.getheader("Content-Length")), len(file_contents), "Wrong Content-Length in HEAD response")
 
         pagesize = 100
         for page_start in range(0, len(file_contents), pagesize):


### PR DESCRIPTION
Two enhancements to make it easier to fetch cores in a `nuocmd diagnose-info` plugin:
* Change the return type of the `/cores` hook from a list of lists to a list of maps.
* Add support for the `HEAD` method as a synonym of `GET`.