### PR TITLE
Added request/response logging

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN set -ex; \
     apt-get install -y --no-install-recommends \
     libnss-wrapper \
     procps \
+    curl \
     ; \
     rm -rf /var/lib/apt/lists/*
 

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -23,6 +23,7 @@ import cores
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 LOGGER = logging.getLogger(__name__)
+REQ_LOGGER = logging.getLogger("RequestLog")
 
 ARCHIVE_DIR = os.environ.get("NUODB_ARCHIVE_DIR", "/mnt/archive")
 JOURNAL_DIR = os.environ.get("NUODB_JOURNAL_DIR")
@@ -823,7 +824,12 @@ def read_handler_config(handler_config):
 
 
 class RequestInfo(object):  # pylint: disable=too-few-public-methods
+
+    _request_counter = 0
+    _lock = Lock()
+
     def __init__(self, environ):
+        self.id = self._next_request_id()
         self.method = environ.get("REQUEST_METHOD")
         # Parse URL and make sure it contains at least one path component
         uri = wsgiref.util.request_uri(environ)
@@ -834,6 +840,12 @@ class RequestInfo(object):  # pylint: disable=too-few-public-methods
         # Decode query parameters and payload
         self.query_params = get_query_params(self.parsed.query)
         self.payload = get_payload(environ)
+
+    @classmethod
+    def _next_request_id(cls):
+        with cls._lock:
+            cls._request_counter += 1
+            return cls._request_counter
 
 
 def handle_method(req):
@@ -896,7 +908,9 @@ def create_response(environ, start_response, status, data=None):
     headers = []
     if isinstance(data, os.PathLike):
         resp = werkzeug.utils.send_file(data, environ, as_attachment=True)
-        return resp(environ, start_response)
+        return resp(environ, start_response), [
+            ("Content-Type", "application/octet-stream")
+        ]
     if isinstance(data, bytes):
         # If data can be decoded as JSON, use application/json
         try:
@@ -909,7 +923,7 @@ def create_response(environ, start_response, status, data=None):
         data = json.dumps(data, indent=4).encode("utf-8") + b"\n"
         headers.append(("Content-Type", "application/json"))
     start_response(status_str, headers)
-    return [data]
+    return [data], headers
 
 
 class HooksHandler(object):
@@ -958,8 +972,7 @@ class HooksHandler(object):
         if custom_handlers:
             LOGGER.info("Custom handlers:\n%s", "\n".join(custom_handlers))
 
-    def handle(self, environ):
-        req = RequestInfo(environ)
+    def handle(self, req):
         start_time = time.time()
         status = http.HTTPStatus.OK
         path = f"/{'/'.join(req.components)}"
@@ -989,9 +1002,40 @@ class HooksHandler(object):
                 str(status),
             ).observe(time.time() - start_time)
 
+    @staticmethod
+    def content_type(headers):
+        for k, v in headers:
+            if k == "Content-Type":
+                return v
+        return "application/octet-stream"
+
+    @staticmethod
+    def log_request(req):
+        if normalize_path(req.parsed.path) == "metrics":
+            # skip metrics endpoint
+            return
+        REQ_LOGGER.info("%d -> %s %s", req.id, req.method, req.parsed.path)
+        if req.payload:
+            REQ_LOGGER.info("%d -> %s", req.id, req.payload)
+
+    @staticmethod
+    def log_response(req, status, headers, resp):
+        if normalize_path(req.parsed.path) == "metrics":
+            # skip metrics endpoint
+            return
+        status_str = "{0.value} {0.phrase}".format(status)
+        REQ_LOGGER.info("%d <- %s", req.id, status_str)
+        if HooksHandler.content_type(headers) in ("application/json", "text/plain"):
+            for data in resp:
+                REQ_LOGGER.info("%d <- %s", req.id, data.decode("utf-8"))
+
     def __call__(self, environ, start_response):
-        status, json_response = self.handle(environ)
-        return create_response(environ, start_response, status, json_response)
+        req = RequestInfo(environ)
+        self.log_request(req)
+        status, data = self.handle(req)
+        resp, headers = create_response(environ, start_response, status, data)
+        self.log_response(req, status, headers, resp)
+        return resp
 
 
 def start_server(port, handler_config):

--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -551,6 +551,8 @@ class ScriptCancelationRule(CancelationRule):
             env=dict(os.environ),
             timeout=self.timeout,
         )
+        if out is None or len(out) == 0:
+            return 0.0
         return float(out.decode("utf-8"))
 
 

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -23,7 +23,7 @@ import tempfile
 import metrics
 import backup_hooks
 import cores
-from backup_hooks import HooksHandler, LOGGER
+from backup_hooks import HooksHandler, LOGGER, REQ_LOGGER
 
 LOGGER.setLevel(logging.DEBUG)
 
@@ -416,6 +416,82 @@ class HttpHandlersTests(unittest.TestCase):
         data = json.loads(data)
         self.assertFalse(data["success"])
         self.assertEqual(data["message"], f"No handler found for path {test_path}")
+
+    @ConfigOverrides(
+        custom_handlers=[
+            {
+                "method": "POST",
+                "path": "/echo",
+                "script": "echo ${payload}",
+            },
+            {
+                "method": "GET",
+                "path": "/exit",
+                "script": "exit ${code:=0}",
+                "statusMappings": {"1": 500, "2": 400},
+            },
+        ]
+    )
+    def testRequestLog(self):
+        def assertRequestLogs(logs, req_id, method, path, status, payload=None):
+            assert any(
+                f"{req_id} -> {method} {path}" in record.message
+                for record in logs.records
+            ), logs.output
+            if payload:
+                assert any(
+                    f"{req_id} -> {payload}" in record.message
+                    for record in logs.records
+                ), logs.output
+            assert any(
+                f"{req_id} <- {status.value} {status.phrase}" in record.message
+                for record in logs.records
+            ), logs.output
+            if payload:
+                assert any(
+                    f"{req_id} <- {payload}" in record.message
+                    for record in logs.records
+                ), logs.output
+
+        with self.assertLogs(logger=REQ_LOGGER) as logs:
+            resp, data = self.request(method="POST", path="/echo", body="hello")
+            self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+            assertRequestLogs(logs, 1, "POST", "/echo", http.HTTPStatus.OK, "hello")
+
+        with self.assertLogs(logger=REQ_LOGGER) as logs:
+            resp, data = self.request(
+                method="POST", path="/echo", body='{"message": "Hello"}'
+            )
+            self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+            assertRequestLogs(
+                logs, 2, "POST", "/echo", http.HTTPStatus.OK, '{"message": "Hello"}'
+            )
+
+        with self.assertLogs(logger=REQ_LOGGER) as logs:
+            resp, data = self.request(method="GET", path="/exit")
+            self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+            assertRequestLogs(logs, 3, "GET", "/exit", http.HTTPStatus.OK)
+
+        with self.assertLogs(logger=REQ_LOGGER) as logs:
+            resp, data = self.request(method="GET", path="/exit?code=1")
+            self.assertEqual(
+                http.HTTPStatus.INTERNAL_SERVER_ERROR, resp.status, str(data)
+            )
+            assertRequestLogs(
+                logs, 4, "GET", "/exit", http.HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+
+        with self.assertLogs(logger=REQ_LOGGER) as logs:
+            resp, data = self.request(method="GET", path="/exit?code=2")
+            self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status, str(data))
+            assertRequestLogs(logs, 5, "GET", "/exit", http.HTTPStatus.BAD_REQUEST)
+
+            # verfy that /metrics endpoint is excluded from request logs
+            resp, data = self.request(method="GET", path="/metrics")
+            self.assertEqual(http.HTTPStatus.OK, resp.status, str(data))
+            assert not any(
+                f"-> GET /metrics" in record.message for record in logs.records
+            ), logs.output
 
 
 class BackupHooksTest(HttpHandlersTests):


### PR DESCRIPTION
**Changes**

This change adds request/response logging for the operational sidecar.
Added `curl` to the image for easy access to NuoDB metrics for custom backup cancellation rules.
Fixed an issue where script cancellation rules return no output. Such rules are evaluated as zero (0) value.

**Testing**
- unit testing

**Example**

```
2026-07-07 11:39:32,711 INFO Built-in handlers:
    GET /metrics
    GET /cores
    GET /cores/{core_name}
    DELETE /cores/{core_name}
    POST /pre-backup/{backup_id}
    POST /post-backup/{backup_id}
2026-07-07 11:39:32,712 INFO Custom handlers:
    GET /operation/{script}/execute
    GET /operation/{operation_id}/logs
2026-07-07 11:39:32,712 INFO Starting operations server on port 3335
2026-07-07 11:39:32,714 INFO Serving on http://0.0.0.0:3335
2026-07-07 11:46:50,507 INFO 1 -> GET /operation/preBackupScript.sh/execute
2026-07-07 11:46:50,541 INFO 2 -> POST /pre-backup/pipeline
2026-07-07 11:46:50,547 INFO 2 <- 200 OK
2026-07-07 11:46:50,547 INFO 2 <- {
    "success": true
}

2026-07-07 11:46:50,797 INFO 1 <- 200 OK
2026-07-07 11:46:50,797 INFO 1 <- {
  "logPath": "/operation/c81c5de4-848f-4c3c-9707-11856d99fbd4/logs",
  "id": "c81c5de4-848f-4c3c-9707-11856d99fbd4",
  "message": "preBackupScript.sh executed."
}

2026-07-07 11:46:53,808 INFO 3 -> GET /operation/c81c5de4-848f-4c3c-9707-11856d99fbd4/logs
2026-07-07 11:46:53,851 INFO 3 <- 200 OK
2026-07-07 11:46:53,851 INFO 3 <- {
  "output": "2026-07-07T11:46:50.521+0000 INFO  [c81c5de4-848f-4c3c-9707-11856d99fbd4] boaas Calling pre-backup hook operationId=c81c5de4-848f-4c3c-9707-11856d99fbd4 ...\n2026-07-07T11:46:50.556+0000 INFO  [c81c5de4-848f-4c3c-9707-11856d99fbd4] boaas Output from pre-backup hook: rc=0, out=<curl -X POST http://localhost:3335/pre-backup/pipeline 200\n-----------------\n{\n    \"success\": true\n}\n----------------->\n2026-07-07T11:46:50.794+0000 INFO  [c81c5de4-848f-4c3c-9707-11856d99fbd4] boaas Database password stored in the backup",
  "exitValue": 0,
  "succeed": true,
  "ended": true
}

2026-07-07 11:47:17,396 INFO 4 -> GET /operation/postBackupScript.sh/execute
2026-07-07 11:47:17,419 INFO 5 -> POST /post-backup/pipeline
2026-07-07 11:47:17,421 INFO 5 <- 200 OK
2026-07-07 11:47:17,421 INFO 5 <- {
    "success": true
}

2026-07-07 11:47:17,435 INFO 4 <- 200 OK
2026-07-07 11:47:17,435 INFO 4 <- {
  "logPath": "/operation/97ab9fb2-226a-47da-89b9-403c46628144/logs",
  "id": "97ab9fb2-226a-47da-89b9-403c46628144",
  "message": "postBackupScript.sh executed."
}

2026-07-07 11:47:20,444 INFO 6 -> GET /operation/97ab9fb2-226a-47da-89b9-403c46628144/logs
2026-07-07 11:47:20,485 INFO 6 <- 200 OK
2026-07-07 11:47:20,485 INFO 6 <- {
  "output": "2026-07-07T11:47:17.409+0000 INFO  [97ab9fb2-226a-47da-89b9-403c46628144] boaas Calling post-backup hook operationId=97ab9fb2-226a-47da-89b9-403c46628144 ...\n2026-07-07T11:47:17.429+0000 INFO  [97ab9fb2-226a-47da-89b9-403c46628144] boaas Output from post-backup hook: rc=0, out=<curl -X POST http://localhost:3335/post-backup/pipeline 200\n-----------------\n{\n    \"success\": true\n}\n----------------->",
  "exitValue": 0,
  "succeed": true,
  "ended": true
}
```