### PR TITLE
Explicitly convert rule threshold to float

### DIFF
--- a/nuodb-operations/backup_hooks.py
+++ b/nuodb-operations/backup_hooks.py
@@ -459,7 +459,7 @@ OPS = {
 class CancelationRule:
 
     RULE_TYPE = None
-    MSG_FMT = "{rule.name} value {value:.2f} is {rule.op} {rule.threshold} for more than {rule.duration}s"  # pylint: disable=line-too-long
+    MSG_FMT = "{rule.name} value {value:.2f} is {rule.op} {rule.threshold:.2f} for more than {rule.duration}s"  # pylint: disable=line-too-long
 
     def __init__(
         self, name, op, threshold, duration=60, **kwargs
@@ -467,8 +467,8 @@ class CancelationRule:
         self.name = name
         self.check = OPS[op][0]
         self.op = OPS[op][1]
-        self.threshold = threshold
-        self.duration = duration
+        self.threshold = float(threshold)
+        self.duration = int(duration)
         self._alert_time = None
 
     def apply(self, **kwargs):
@@ -483,7 +483,7 @@ class CancelationRule:
             if self.check(value, self.threshold):
                 if self._alert_time is None:
                     self._alert_time = now
-                elif now - self._alert_time >= self.duration:
+                if now - self._alert_time >= self.duration:
                     return self.MSG_FMT.format(value=value, rule=self)
             else:
                 # reset the time

--- a/nuodb-operations/test_backup_hooks.py
+++ b/nuodb-operations/test_backup_hooks.py
@@ -753,7 +753,7 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
         self._testBackupCancelation(
             set_good,
             set_bad,
-            "Journal volume utilization percentage value 85.00 is greater than 80 for more than 5s",
+            "Journal volume utilization percentage value 85.00 is greater than 80.00 for more than 5s",
         )
 
     @ConfigOverrides(
@@ -783,7 +783,7 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
         self._testBackupCancelation(
             set_good,
             set_bad,
-            "Memory throttling value 32.00 is greater than 0 for more than 5s",
+            "Memory throttling value 32.00 is greater than 0.00 for more than 5s",
         )
 
     @ConfigOverrides(
@@ -792,7 +792,7 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
             {
                 "type": "journalUtilization",
                 "op": ">",
-                "threshold": 80,
+                "threshold": "80",
                 "duration": 5,
             },
             {
@@ -820,8 +820,8 @@ class BackupHooksExternalJournalTest(BackupHooksTest):
         self._testBackupCancelation(
             set_good,
             set_bad,
-            "Journal volume utilization percentage value 95.00 is greater than 80 for more than 5s; "
-            + "Memory throttling value 32.00 is greater than 0 for more than 5s",
+            "Journal volume utilization percentage value 95.00 is greater than 80.00 for more than 5s; "
+            + "Memory throttling value 32.00 is greater than 0.00 for more than 5s",
         )
 
     @ConfigOverrides(


### PR DESCRIPTION
**Changes**

This change converts the cancellation rule threshold value to `float`. This is
useful so that numbers encoded as string values can be passed via Helm values.

Cancel the backup operation immediately when evaluating a rule with `0` duration.